### PR TITLE
Fix incorrect solana reference in web3 snippet. Remove unused buildLoginUrl function

### DIFF
--- a/integration/nodejs/express.mdx
+++ b/integration/nodejs/express.mdx
@@ -134,8 +134,6 @@ app.use((req, res, next) => {
 This endpoint will handle login requests, build the Civic login URL and redirect the user to it.
 
 ```ts
-import { buildLoginUrl } from "@civic/auth/server";
-
 app.get("/auth/login-url", async (req: Request, res: Response) => {
  const frontendState = req.query.state as string | undefined;
 

--- a/web3/solana.mdx
+++ b/web3/solana.mdx
@@ -85,7 +85,7 @@ if (userHasWallet(userContext)) {
 
 ```tsx
 const connection = new Connection(/* your rpc endpoint */);
-const { publicKey, sendTransaction } = user.sol.wallet;
+const { publicKey, sendTransaction } = user.solana.wallet;
 
 const transaction = new Transaction().add(
   SystemProgram.transfer({


### PR DESCRIPTION
- Fix incorrect solana reference in web3 snippet. 
- Remove unused buildLoginUrl function