### PR TITLE
TECH-2301: Add Python SDK disclaimer to snippets

### DIFF
--- a/integration/python/django.mdx
+++ b/integration/python/django.mdx
@@ -5,9 +5,13 @@ icon: layer-group
 public: true
 ---
 
+import PythonSdkWarning from '/snippets/_python-sdk-warning.mdx';
+
 <Info>
 **Prefer AI-assisted setup?** Use our [AI prompts for Django](/ai-prompts/python/django) to automatically integrate Civic Auth using Claude, ChatGPT, or other AI assistants. Includes a step-by-step video tutorial!
 </Info>
+
+<PythonSdkWarning />
 
 ## Quick Start
 

--- a/integration/python/fastapi.mdx
+++ b/integration/python/fastapi.mdx
@@ -5,11 +5,15 @@ icon: bolt
 public: true
 ---
 
+import PythonSdkWarning from '/snippets/_python-sdk-warning.mdx';
+
 <Info>
 **Prefer AI-assisted setup?** Use our [AI prompts for FastAPI](/ai-prompts/python/fastapi) to automatically integrate Civic Auth using Claude, ChatGPT, or other AI assistants. Includes a step-by-step video tutorial!
 </Info>
 
 ## Quick Start
+
+<PythonSdkWarning />
 
 ### 1. Install Dependencies
 

--- a/integration/python/flask.mdx
+++ b/integration/python/flask.mdx
@@ -5,10 +5,13 @@ icon: fire
 public: true
 ---
 
+import PythonSdkWarning from '/snippets/_python-sdk-warning.mdx';
+
 <Info>
 **Prefer AI-assisted setup?** Use our [AI prompts for Flask](/ai-prompts/python/flask) to automatically integrate Civic Auth using Claude, ChatGPT, or other AI assistants. Includes a step-by-step video tutorial!
 </Info>
 
+<PythonSdkWarning />
 
 ## 1. Install dependencies
 

--- a/snippets/_python-sdk-warning.mdx
+++ b/snippets/_python-sdk-warning.mdx
@@ -1,0 +1,10 @@
+<Warning>
+**Important: The SDK Handles Everything**
+
+The Civic Auth Python SDK abstracts away all token validation complexity. You do **NOT** need to:
+- Implement custom middleware for token validation
+- Parse or validate JWT tokens manually  
+- Handle token refresh logic yourself
+
+Simply use the provided decorators and user access functions - the SDK handles all authentication logic for you.
+</Warning>

--- a/snippets/django.mdx
+++ b/snippets/django.mdx
@@ -66,6 +66,7 @@ Using ONLY the documentation fetched via curl:
 - The civic_user is available on request.civic_user with attributes like .name, .email, .id, .picture
 - Middleware must be added to MIDDLEWARE list in settings.py
 - URLs must include get_auth_urls() for authentication routes
+- **CRITICAL**: The SDK handles ALL token validation - DO NOT implement custom middleware for token parsing/validation
 
 ## CRITICAL: Information Gathering Requirements
 You MUST gather ALL required information from the user before proceeding with ANY implementation steps:

--- a/snippets/fastapi.mdx
+++ b/snippets/fastapi.mdx
@@ -57,6 +57,7 @@ Using ONLY the documentation fetched via curl:
 - Pay attention to Python version requirements and dependency compatibility
 - Ensure proper virtual environment setup if needed
 - The get_current_user dependency returns a dictionary, use user.get('field') for safe access
+- **CRITICAL**: The SDK handles ALL token validation - DO NOT implement custom middleware for token parsing/validation
 
 ## CRITICAL: Information Gathering Requirements
 You MUST gather ALL required information from the user before proceeding with ANY implementation steps:

--- a/snippets/flask.mdx
+++ b/snippets/flask.mdx
@@ -57,6 +57,7 @@ Using ONLY the documentation fetched via curl:
 - Pay attention to Python version requirements and dependency compatibility
 - Ensure proper virtual environment setup if needed
 - The get_civic_user() function returns a dictionary, use user.get('field') for safe access
+- **CRITICAL**: The SDK handles ALL token validation - DO NOT implement custom middleware for token parsing/validation
 
 ## CRITICAL: Information Gathering Requirements
 You MUST gather ALL required information from the user before proceeding with ANY implementation steps:


### PR DESCRIPTION
This lets users know that the Python SDK handles everything, so they don't need to implement custom middleware for token validation, parse or validate JWT tokens manually, or handle token refresh logic themselves.