### PR TITLE
TECH-2600: Added fix: add POST to handler docs

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -34,6 +34,6 @@ https://github.com/civicteam/mcp-tools
 https://github.com/civicteam/bodyguard
 # Private labs links
 # not deployed yet
-https://ai.civic.com/bodyguard/ui
+https://nexus.civic.com/bodyguard/ui
 # NPM page returning error
 https://www.npmjs.com/package/@civic/auth-mcp#-framework-agnostic-usage

--- a/integration/nextjs.mdx
+++ b/integration/nextjs.mdx
@@ -85,6 +85,7 @@ Create this file at the following path:
 import { handler } from "@civic/auth/nextjs"
 
 export const GET = handler()
+export const POST = handler()
 ```
   </Tab>
   <Tab title="Auth + Web3">
@@ -92,6 +93,7 @@ export const GET = handler()
 import { handler } from "@civic/auth-web3/nextjs"
 
 export const GET = handler()
+export const POST = handler()
 ```
   </Tab>
 </Tabs>

--- a/labs/n8n_sample_api-key-flow.json
+++ b/labs/n8n_sample_api-key-flow.json
@@ -59,7 +59,7 @@
     },
     {
       "parameters": {
-        "sseEndpoint": "https://ai.civic.com/api/hub/mcp",
+        "sseEndpoint": "https://nexus.civic.com/api/hub/mcp",
         "authentication": "headerAuth"
       },
       "type": "@n8n/n8n-nodes-langchain.mcpClientTool",

--- a/labs/private/bodyguard.mdx
+++ b/labs/private/bodyguard.mdx
@@ -12,10 +12,10 @@ Deploy Bodyguard as a standalone service that other applications can query:
 
 ```bash
 # GET request
-curl "https://ai.civic.com/bodyguard/check?prompt=Your%20prompt%20here"
+curl "https://nexus.civic.com/bodyguard/check?prompt=Your%20prompt%20here"
 
 # POST request
-curl -X POST https://ai.civic.com/bodyguard/check \
+curl -X POST https://nexus.civic.com/bodyguard/check \
   -H "X-API-Key: your_api_key_here"
   -H "Content-Type: application/json" \
   -d '{"prompt":"Your prompt here"}'
@@ -46,7 +46,7 @@ Bodyguard can be used as a middleware hook for MCP servers, analyzing prompts be
     "command": "passthrough-mcp-server",
     "env": [
       "TARGET_SERVER_URL", "https://my-mcp-server",
-      "HOOKS", "https://ai.civic.com/bodyguard/hook?threshold=0.7"
+      "HOOKS", "https://nexus.civic.com/bodyguard/hook?threshold=0.7"
     ]
   }
 }

--- a/labs/private/getting-started.mdx
+++ b/labs/private/getting-started.mdx
@@ -97,7 +97,7 @@ Most Civic Labs projects are in active development. To get behind-the-scenes acc
 
 Some projects have public demos available:
 
-- **MCP Hub**: [Try our example MCP servers](https://ai.civic.com)
+- **MCP Hub**: [Try our example MCP servers](https://nexus.civic.com)
 - **Civic Knowledge**: Coming soon
 - **Guardrail Proxy**: Interactive playground coming soon
 

--- a/labs/private/mcp-hub.mdx
+++ b/labs/private/mcp-hub.mdx
@@ -8,7 +8,7 @@ description: Implementation details and integration guides for MCP Hub
 The MCP Hub endpoint is:
 
 ```
-https://ai.civic.com/hub/mcp
+https://nexus.civic.com/hub/mcp
 ```
 
 ## Authentication
@@ -110,7 +110,7 @@ const { accessToken } = await getTokens()
 // Create MCP client
 const createMCPClient = async () => {
   const transport = new StreamableHTTPClientTransport(
-    'https://ai.civic.com/hub/mcp',
+    'https://nexus.civic.com/hub/mcp',
     {
       requestInit: {
         headers: {
@@ -159,7 +159,7 @@ For custom integrations, use the MCP Hub API directly:
 
 ```javascript
 // List available MCP servers
-const response = await fetch('https://ai.civic.com/hub/mcp', {
+const response = await fetch('https://nexus.civic.com/hub/mcp', {
   method: 'POST',
   headers: {
     'Authorization': `Bearer ${apiKey}`,

--- a/labs/projects/bodyguard.mdx
+++ b/labs/projects/bodyguard.mdx
@@ -19,7 +19,7 @@ catching sophisticated attacks that might bypass traditional filters.
 
 ## Getting Started
 
-Try it out [here](https://ai.civic.com/bodyguard/ui) (COMING SOON). For detailed usage instructions, see the [implementation guide](/labs/private/bodyguard).
+Try it out [here](https://nexus.civic.com/bodyguard/ui) (COMING SOON). For detailed usage instructions, see the [implementation guide](/labs/private/bodyguard).
 
 ## Use Cases
 


### PR DESCRIPTION
Add an instruction to use POST as well as GET when defining routeHandlers for civic/auth and civic/auth-web3.

Replace ai.civic.com references with nexus.civic.com

Preview at https://civic-feature-tech-2600--routehandler-post-support.mintlify.app/ 