### PR TITLE
Add uv as an alternative installation method in our python docs

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -73,6 +73,10 @@ bun add @civic/auth
 pip install civic-auth
 ```
 
+```python uv
+uv add civic-auth
+```
+
 </CodeGroup>
 
 ## Web3 Wallets

--- a/integration/python.mdx
+++ b/integration/python.mdx
@@ -51,6 +51,22 @@ pip install "civic-auth[django]"
 ```
 </CodeGroup>
 
+If you're using the `uv` package manager:
+
+<CodeGroup>
+```bash FastAPI
+uv add "civic-auth[fastapi]"
+```
+
+```bash Flask
+uv add "civic-auth[flask]"
+```
+
+```bash Django
+uv add "civic-auth[django]"
+```
+</CodeGroup>
+
 ## Usage
 
 The Civic Auth Python SDK provides a flexible API that works with any Python web framework. For framework-specific integrations, see the guides above.

--- a/integration/python/django.mdx
+++ b/integration/python/django.mdx
@@ -21,6 +21,12 @@ import PythonSdkWarning from '/snippets/_python-sdk-warning.mdx';
 pip install "civic-auth[django]"
 ```
 
+Or, if you're using the `uv` package manager:
+
+```bash
+uv add "civic-auth[django]"
+```
+
 ### 2. Configure Your Django Settings
 
 Add Civic Auth configuration to your Django settings:

--- a/integration/python/fastapi.mdx
+++ b/integration/python/fastapi.mdx
@@ -21,6 +21,12 @@ import PythonSdkWarning from '/snippets/_python-sdk-warning.mdx';
 pip install "civic-auth[fastapi]"
 ```
 
+Or, if you're using the `uv` package manager:
+
+```bash
+uv add "civic-auth[fastapi]"
+```
+
 ### 2. Create Your App with Authentication
 
 Create your FastAPI app with Civic Auth integration:

--- a/integration/python/flask.mdx
+++ b/integration/python/flask.mdx
@@ -19,6 +19,12 @@ import PythonSdkWarning from '/snippets/_python-sdk-warning.mdx';
 pip install "civic-auth[flask]"
 ```
 
+Or, if you're using the `uv` package manager:
+
+```bash
+uv add "civic-auth[flask]"
+```
+
 ## 2. Configure your App
 
 Your app will need the following configuration:


### PR DESCRIPTION
Add uv as an alternative installation method in our python docs. For example:

<img width="955" height="333" alt="Screenshot 2025-09-16 at 17 50 58" src="https://github.com/user-attachments/assets/03ff4f99-2b8f-421a-b9a3-079837c7f881" />
