### PR TITLE
Remove bolt page until we can refine the ai prompt to cover bolt

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -87,7 +87,6 @@
               "icon": "wand-magic-sparkles",
               "pages": [
                 "ai-prompts/no-code/lovable",
-                "ai-prompts/no-code/bolt",
                 "ai-prompts/no-code/v0",
                 "ai-prompts/no-code/replit"
               ]


### PR DESCRIPTION
The Ai prompt needs refinement before we can support Bolt. Removing coming soon page until it is ready.