### PR TITLE
Reorder navigation: Make Nexus the primary product

### DIFF
--- a/auth/index.mdx
+++ b/auth/index.mdx
@@ -1,0 +1,148 @@
+---
+title: "Civic Auth"
+icon: "lock"
+description: "Civic Auth is a simple, flexible, and fast way to integrate authentication into your applications. Enable familiar sign-in options while offering optional embedded wallets and unlocking blockchain benefits for your users."
+sidebarTitle: "Getting Started"
+public: true
+---
+
+## What is Civic Auth?
+
+<Info>
+  Civic Auth is currently in **beta**. Please expect occasional changes or updates as we continue to refine the experience.
+</Info>
+
+<Frame caption="Civic Auth: User-Facing View">
+  <img
+    src="/login.png"
+    align="center"
+    className="image-60 image-rounded"
+    alt=""
+    title=""
+  />
+</Frame>
+
+<CardGroup cols={2}>
+  <Card title="Integrated login." icon="user">
+    Users sign in using their email, Google account, or wallet. No complex setup required.
+  </Card>
+  <Card title="Adaptable onboarding." icon="user-plus">
+    Auth is a familiar sign-in experience for all users. Supports existing wallets or integrated embedded wallets.
+  </Card>
+  <Card title="Embedded wallets." icon="wallet">
+    Automatically create [Web3 wallets](/web3/embedded-wallets) for your users.
+  </Card>
+  <Card title="Multichain support." icon="gear">
+    Supported on Solana, as well as Base, Binance Smart Chain (BSC), Polygon, Arbitrum, Ethereum, and other EVM-compatible chains.
+  </Card>
+</CardGroup>
+
+## Quick Start
+
+Sign up for Civic Auth in less than a minute at [auth.civic.com](https://auth.civic.com) to get your Client ID.
+
+<Frame caption="Civic Auth: Admin Dashboard - Integration Steps">
+  ![](/images/image-2.png)
+</Frame>
+
+Install the library in your app.
+
+<CodeGroup>
+
+```npm npm
+npm install @civic/auth
+```
+
+
+```yarn yarn
+yarn add @civic/auth
+```
+
+
+```pnpm pnpm
+pnpm install @civic/auth
+```
+
+
+```bun bun
+bun add @civic/auth
+```
+
+
+```python pip
+pip install civic-auth
+```
+
+```python uv
+uv add civic-auth
+```
+
+</CodeGroup>
+
+## Web3 Wallets
+
+If you plan to offer your users [Web3 wallets](#web3-wallets), you can use the Civic Auth Web3 SDK.
+
+<Frame caption="Civic Auth: Admin Dashboard - Web3 Wallets Support">
+  ![](/images/image-3.png)
+</Frame>
+
+This SDK extends the functionality of the base Civic Auth SDK to add Web3 features.
+
+<CodeGroup>
+
+```npm-1 npm
+npm install @civic/auth-web3
+```
+
+
+```yarn-1 yarn
+yarn add @civic/auth-web3
+```
+
+
+```pnpm-1 pnpm
+pnpm install @civic/auth-web3
+```
+
+
+```bun-1 bun
+bun add @civic/auth-web3
+```
+
+</CodeGroup>
+
+### Usage
+
+Choose your framework for instructions on how to integrate Civic Auth into your application.
+
+<CardGroup cols={3}>
+  <Card href="/integration/react" img="/images/image-4.png">
+    React
+  </Card>
+  <Card href="/integration/nextjs" img="/images/image-5.jpeg">
+    Next.JS
+  </Card>
+  <Card href="/integration/vanillajs" img="/images/image-8.png">
+    Vanilla JavaScript
+  </Card>
+  <Card href="/integration/nodejs" img="/images/image-6.png">
+    Node.JS
+  </Card>
+  <Card href="/integration/python" img="/images/image-7.png">
+    Python
+  </Card>
+  <Card href="/integration/mobile/react-native" img="/images/image-4.png">
+    React Native
+  </Card>
+</CardGroup>
+
+For integrating in other environments using any OIDC or OAuth 2.0-compliant client libraries, see [here](/integration/other).
+
+### Civic Auth Demo
+
+Don't take our word for it. See Civic Auth in action:
+
+<Frame>
+  <iframe width="100%" height="420" src="https://www.youtube.com/embed/0VqK56JqIL0" title="Demo - Civic Auth for seamless user management" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
+</Frame>

--- a/docs.json
+++ b/docs.json
@@ -36,292 +36,296 @@
     }
   },
   "navigation": {
-    "tabs": [{
-      "tab": "Auth",
-      "groups": [
-        {
-          "group":  "Getting Started",
-          "pages": [
-            "index",
-            "overview/pricing",
-            "overview/bring-your-app-to-production",
+    "tabs": [
+      {
+        "tab": "Nexus",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "icon": "rocket",
+            "pages": [
+              "index",
+              "nexus/quickstart/index",
+              "nexus/concepts/toolkits",
+              "nexus/reference/authorizations"
+            ]
+          },
+          {
+            "group": "Supported Clients",
+            "icon": "desktop",
+            "pages": [
+              "nexus/quickstart/nexus-chat",
+              "nexus/quickstart/clients/mistral-lechat",
+              "nexus/quickstart/clients/claude-web",
+              "nexus/quickstart/clients/claude-desktop",
+              {
+                "group": "More Clients",
+                "icon": "ellipsis",
+                "pages": [
+                  "nexus/quickstart/clients/cursor",
+                  "nexus/quickstart/clients/goose",
+                  "nexus/quickstart/clients/vscode",
+                  "nexus/quickstart/clients/windsurf",
+                  "nexus/quickstart/clients/claude-code",
+                  "nexus/quickstart/clients/codex",
+                  "nexus/quickstart/clients/jetbrains",
+                  "nexus/quickstart/clients/gemini"
+                ]
+              },
+              {
+                "group": "MCP Servers",
+                "icon": "server",
+                "pages": [
+                  "nexus/reference/servers",
+                  "nexus/reference/servers/activecampaign",
+                  "nexus/reference/servers/github",
+                  "nexus/reference/servers/slack",
+                  "nexus/reference/servers/notion",
+                  "nexus/reference/servers/n8n",
+                  "nexus/reference/servers/postgresql",
+                  "nexus/reference/servers/sentry",
+                  "nexus/reference/servers/linear",
+                  "nexus/reference/servers/hubspot",
+                  "nexus/reference/servers/dropbox",
+                  "nexus/reference/servers/coingecko"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Developers",
+            "icon": "code",
+            "pages": [
+              {
+                "group": "IDE Setup",
+                "icon": "code",
+                "pages": [
+                  "nexus/developers/client-setup",
+                  "nexus/quickstart/hub-bridge"
+                ]
+              },
+              {
+                "group": "AI SDKs",
+                "icon": "plug",
+                "pages": [
+                  "nexus/developers/integrations/index",
+                  "nexus/recipes/vercel-ai-sdk",
+                  "nexus/recipes/openai-agents",
+                  "nexus/recipes/anthropic",
+                  "nexus/recipes/openai-sdk",
+                  "nexus/recipes/python-pydantic"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Reference",
+            "icon": "book",
+            "pages": [
+              "nexus/reference/client-compatibility",
+              "nexus/reference/security"
+            ]
+          },
+          {
+            "group": "AI Prompts",
+            "icon": "robot",
+            "pages": [
+              "nexus/ai-prompts/nextjs"
+            ]
+          },
+          {
+            "group": "Support",
+            "icon": "life-buoy",
+            "pages": [
+              "nexus/troubleshooting"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Auth",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "auth/index",
+              "overview/pricing",
+              "overview/bring-your-app-to-production",
+              {
+                "group": "Login Options",
+                "icon": "arrow-right-to-bracket",
+                "pages": [
+                  "overview/login-options",
+                  "overview/passkeys"
+                ]
+              },
+              "overview/faqs",
+              "overview/authentication-flows",
+              "overview/changelog"
+            ]
+          },
+          {
+            "group": "AI Prompts",
+            "icon": "robot",
+            "pages": [
+              "ai-prompts/overview",
+              "ai-prompts/nextjs",
+              "ai-prompts/react",
+              {
+                "group": "Python",
+                "icon": "python",
+                "pages": [
+                  "ai-prompts/python/fastapi",
+                  "ai-prompts/python/flask",
+                  "ai-prompts/python/django"
+                ]
+              },
+              {
+                "group": "Web3",
+                "icon": "wallet",
+                "pages": [
+                  "ai-prompts/web3/solana",
+                  "ai-prompts/web3/ethereum"
+                ]
+              },
+              {
+                "group": "No-code Platforms",
+                "icon": "wand-magic-sparkles",
+                "pages": [
+                  "ai-prompts/no-code/lovable",
+                  "ai-prompts/no-code/v0",
+                  "ai-prompts/no-code/replit"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Integration",
+            "pages": [
+              "integration/react",
+              "integration/nextjs",
+              "integration/vanillajs",
+              {
+                "group": "Node.JS",
+                "icon": "node-js",
+                "pages": [
+                  "integration/nodejs",
+                  "integration/nodejs/express",
+                  "integration/nodejs/hono",
+                  "integration/nodejs/fastify"
+                ]
+              },
+              {
+                "group": "Python",
+                "icon": "python",
+                "pages": [
+                  "integration/python",
+                  "integration/python/fastapi",
+                  "integration/python/flask",
+                  "integration/python/django"
+                ]
+              },
+              {
+                "group": "Mobile",
+                "icon": "mobile-screen-button",
+                "pages": [
+                  "integration/mobile/react-native"
+                ]
+              },
+              "integration/other",
+              "integration/error-codes"
+            ]
+          },
+          {
+            "group": "Web3",
+            "pages": [
+              "web3/embedded-wallets",
+              "web3/ethereum-evm",
+              "web3/solana"
+            ]
+          },
+          {
+            "group": "Libraries & Tools",
+            "icon": "code",
+            "pages": [
+              "libraries/auth-verify"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "guides/add-auth-to-mcp"
+            ]
+          }
+        ],
+        "global": {
+          "anchors": [
             {
-              "group": "Login Options",
-              "icon": "arrow-right-to-bracket",
-              "pages": [
-                "overview/login-options",
-                "overview/passkeys"
-              ]
+              "anchor": "About us",
+              "href": "https://www.civic.com/about",
+              "icon": "circle-info"
             },
-            "overview/faqs",
-            "overview/authentication-flows",
-            "overview/changelog"
-          ]
-        },
-        {
-          "group": "AI Prompts",
-          "icon": "robot",
-          "pages": [
-            "ai-prompts/overview",
-            "ai-prompts/nextjs", 
-            "ai-prompts/react",
             {
-              "group": "Python",
-              "icon": "python",
-              "pages": [
-                "ai-prompts/python/fastapi",
-                "ai-prompts/python/flask",
-                "ai-prompts/python/django"
-              ]
+              "anchor": "Blog",
+              "href": "https://www.civic.com/blog",
+              "icon": "newspaper"
             },
             {
-              "group": "Web3",
-              "icon": "wallet",
-              "pages": [
-                "ai-prompts/web3/solana",
-                "ai-prompts/web3/ethereum"
-              ]
-            },
-            {
-              "group": "No-code Platforms",
-              "icon": "wand-magic-sparkles",
-              "pages": [
-                "ai-prompts/no-code/lovable",
-                "ai-prompts/no-code/v0",
-                "ai-prompts/no-code/replit"
-              ]
+              "anchor": "Join Our Community",
+              "href": "https://join.slack.com/t/civic-developers/shared_invite/zt-37tv9fyo7-aDT43mUjOFQwdQFmfZLTRw",
+              "icon": "slack"
             }
           ]
-        },
-        {
-          "group": "Integration",
-          "pages": [
-            "integration/react",
-            "integration/nextjs",
-            "integration/vanillajs",
-            {
-              "group": "Node.JS",
-              "icon": "node-js",
-              "pages": [
-                "integration/nodejs",
-                "integration/nodejs/express",
-                "integration/nodejs/hono",
-                "integration/nodejs/fastify"
-              ]
-            },
-            {
-              "group": "Python",
-              "icon": "python",
-              "pages": [
-                "integration/python",
-                "integration/python/fastapi",
-                "integration/python/flask",
-                "integration/python/django"
-              ]
-            },
-            {
-              "group": "Mobile",
-              "icon": "mobile-screen-button",
-              "pages": [
-                "integration/mobile/react-native"
-              ]
-            },
-            "integration/other",
-            "integration/error-codes"
-          ]
-        },
-        {
-          "group": "Web3",
-          "pages": [
-            "web3/embedded-wallets",
-            "web3/ethereum-evm",
-            "web3/solana"
-          ]
-        },
-        {
-          "group": "Libraries & Tools",
-          "icon": "code",
-          "pages": [
-            "libraries/auth-verify"
-          ]
-        },
-        {
-          "group": "Guides",
-          "pages": [
-            "guides/add-auth-to-mcp"
-          ]
         }
-      ],
-      "global": {
-        "anchors": [
+      },
+      {
+        "tab": "Labs",
+        "groups": [
           {
-            "anchor": "About us",
-            "href": "https://www.civic.com/about",
-            "icon": "circle-info"
+            "group": " ",
+            "pages": [
+              "labs",
+              "labs/flask-status",
+              "labs/feedback"
+            ]
           },
           {
-            "anchor": "Blog",
-            "href": "https://www.civic.com/blog",
-            "icon": "newspaper"
+            "group": "Flasks",
+            "pages": [
+              "labs/projects/mcp-hub",
+              "labs/projects/x402-mcp",
+              "labs/projects/guardrail-proxy",
+              "labs/projects/bodyguard",
+              "labs/projects/passthrough-proxy",
+              "labs/projects/civic-knowledge"
+            ]
           },
           {
-            "anchor": "Join Our Community",
-            "href": "https://join.slack.com/t/civic-developers/shared_invite/zt-37tv9fyo7-aDT43mUjOFQwdQFmfZLTRw",
-            "icon": "slack"
+            "group": "Concepts",
+            "pages": [
+              "labs/concepts/mcp",
+              "labs/concepts/guardrails",
+              "labs/concepts/prompt-injection",
+              "labs/concepts/auth-strategies",
+              "labs/concepts/hooks",
+              "labs/concepts/rag"
+            ]
+          },
+          {
+            "group": "\ud83d\udd13Integration",
+            "pages": [
+              "labs/private/getting-started",
+              "labs/private/mcp-hub",
+              "labs/private/x402-mcp",
+              "labs/private/guardrail-proxy",
+              "labs/private/bodyguard",
+              "labs/private/passthrough-proxy",
+              "labs/private/civic-knowledge"
+            ]
           }
         ]
       }
-    }, {
-      "tab": "Nexus",
-      "groups": [
-         {
-           "group": "Getting Started",
-           "icon": "rocket",
-           "pages": [
-             "nexus/overview",
-             "nexus/quickstart/index",
-             "nexus/concepts/toolkits",
-             "nexus/reference/authorizations"
-           ]
-         },
-         {
-           "group": "Supported Clients",
-           "icon": "desktop",
-           "pages": [
-             "nexus/quickstart/nexus-chat",
-             "nexus/quickstart/clients/mistral-lechat",
-             "nexus/quickstart/clients/claude-web",
-             "nexus/quickstart/clients/claude-desktop",
-             {
-               "group": "More Clients",
-               "icon": "ellipsis",
-               "pages": [
-                 "nexus/quickstart/clients/cursor",
-                 "nexus/quickstart/clients/goose",
-                 "nexus/quickstart/clients/vscode",
-                 "nexus/quickstart/clients/windsurf",
-                 "nexus/quickstart/clients/claude-code",
-                 "nexus/quickstart/clients/codex",
-                 "nexus/quickstart/clients/jetbrains",
-                 "nexus/quickstart/clients/gemini"
-               ]
-             },
-             {
-               "group": "MCP Servers",
-               "icon": "server",
-               "pages": [
-                 "nexus/reference/servers",
-                 "nexus/reference/servers/activecampaign",
-                 "nexus/reference/servers/github",
-                 "nexus/reference/servers/slack",
-                 "nexus/reference/servers/notion",
-                 "nexus/reference/servers/n8n",
-                 "nexus/reference/servers/postgresql",
-                 "nexus/reference/servers/sentry",
-                 "nexus/reference/servers/linear",
-                 "nexus/reference/servers/hubspot",
-                 "nexus/reference/servers/dropbox",
-                 "nexus/reference/servers/coingecko"
-               ]
-             }
-           ]
-         },
-        {
-          "group": "Developers",
-          "icon": "code",
-          "pages": [
-            {
-              "group": "IDE Setup",
-              "icon": "code",
-              "pages": [
-                "nexus/developers/client-setup",
-                "nexus/quickstart/hub-bridge"
-              ]
-            },
-            {
-              "group": "AI SDKs",
-              "icon": "plug",
-              "pages": [
-                "nexus/developers/integrations/index",
-                "nexus/recipes/vercel-ai-sdk",
-                "nexus/recipes/openai-agents",
-                "nexus/recipes/anthropic",
-                "nexus/recipes/openai-sdk",
-                "nexus/recipes/python-pydantic"
-              ]
-            }
-          ]
-        },
-        {
-          "group": "Reference",
-          "icon": "book",
-          "pages": [
-            "nexus/reference/client-compatibility",
-            "nexus/reference/security"
-          ]
-        },
-        {
-          "group": "AI Prompts",
-          "icon": "robot",
-          "pages": [
-            "nexus/ai-prompts/nextjs"
-          ]
-        },
-        {
-          "group": "Support",
-          "icon": "life-buoy",
-          "pages": [
-            "nexus/troubleshooting"
-          ]
-        }
-      ]
-    },{
-      "tab": "Labs",
-      "groups": [
-        {
-          "group": " ",
-          "pages": [
-            "labs",
-            "labs/flask-status",
-            "labs/feedback"
-          ]
-        },
-        {
-          "group": "Flasks",
-          "pages": [
-            "labs/projects/mcp-hub",
-            "labs/projects/x402-mcp",
-            "labs/projects/guardrail-proxy",
-            "labs/projects/bodyguard",
-            "labs/projects/passthrough-proxy",
-            "labs/projects/civic-knowledge"
-          ]
-        },
-        {
-          "group": "Concepts",
-          "pages": [
-            "labs/concepts/mcp",
-            "labs/concepts/guardrails",
-            "labs/concepts/prompt-injection",
-            "labs/concepts/auth-strategies",
-            "labs/concepts/hooks",
-            "labs/concepts/rag"
-          ]
-        },
-        {
-          "group": "🔓Integration",
-          "pages": [
-            "labs/private/getting-started",
-            "labs/private/mcp-hub",
-            "labs/private/x402-mcp",
-            "labs/private/guardrail-proxy",
-            "labs/private/bodyguard",
-            "labs/private/passthrough-proxy",
-            "labs/private/civic-knowledge"
-          ]
-        }
-      ]
-    }]
+    ]
   },
   "logo": {
     "light": "/logo/light.png",
@@ -337,8 +341,8 @@
     ],
     "primary": {
       "type": "button",
-      "label": "Try Auth",
-      "href": "https://auth.civic.com/dashboard?utm_source=docs&utm_medium=hero-nav"
+      "label": "Try Nexus",
+      "href": "https://nexus.civic.com?utm_source=docs&utm_medium=hero-nav"
     }
   },
   "footer": {

--- a/index.mdx
+++ b/index.mdx
@@ -1,148 +1,235 @@
 ---
-title: "Civic Auth"
-icon: "lock"
-description: "Civic Auth is a simple, flexible, and fast way to integrate authentication into your applications. Enable familiar sign-in options while offering optional embedded wallets and unlocking blockchain benefits for your users."
-sidebarTitle: "Getting Started"
-public: true
+title: Welcome to Civic Nexus
+description: Connect your AI assistant to dozens of MCP servers with hundreds of tools
+icon: "rocket"
+public: false
 ---
 
-## What is Civic Auth?
+## What is Civic Nexus?
 
-<Info>
-  Civic Auth is currently in **beta**. Please expect occasional changes or updates as we continue to refine the experience.
-</Info>
+**Civic Nexus connects your AI assistant to all your tools** - GitHub, Slack, Dropbox, databases, and dozens of other services. Your AI can finally do real work instead of just answering questions.
 
-<Frame caption="Civic Auth: User-Facing View">
-  <img
-    src="/login.png"
-    align="center"
-    className="image-60 image-rounded"
-    alt=""
-    title=""
-  />
-</Frame>
+## How It Works
 
-<CardGroup cols={2}>
-  <Card title="Integrated login." icon="user">
-    Users sign in using their email, Google account, or wallet. No complex setup required.
-  </Card>
-  <Card title="Adaptable onboarding." icon="user-plus">
-    Auth is a familiar sign-in experience for all users. Supports existing wallets or integrated embedded wallets.
-  </Card>
-  <Card title="Embedded wallets." icon="wallet">
-    Automatically create [Web3 wallets](/web3/embedded-wallets) for your users.
-  </Card>
-  <Card title="Multichain support." icon="gear">
-    Supported on Solana, as well as Base, Binance Smart Chain (BSC), Polygon, Arbitrum, Ethereum, and other EVM-compatible chains.
-  </Card>
-</CardGroup>
+### Easiest Way: Try It Directly in Nexus Chat
 
-## Quick Start
+<Steps>
+  <Step title="Sign up at nexus.civic.com">
+    Create your account and browse dozens of available MCP servers (GitHub, Slack, Dropbox, etc.)
+    <Frame caption="Sign up and browse tools">
+      <img
+        className="rounded-lg"
+        src="/images/steps/welcome/01.png"
+        alt="Nexus directory showing available tools"
+      />
+    </Frame>
+  </Step>
+  <Step title="Click 'Chat' to test immediately">
+    Use the built-in chat interface - no setup required, start testing tools right away
+    <Frame caption="Built-in Nexus chat interface">
+      <img
+        className="rounded-lg"
+        src="/images/steps/welcome/02.png"
+        alt="Nexus chat interface ready to use"
+      />
+    </Frame>
+  </Step>
+  <Step title="Ask for what you need">
+    Request tools and authorizations directly in chat: "Connect me to GitHub", "Check my Slack messages"
+    <Frame caption="Tool authorization in chat">
+      <img
+        className="rounded-lg"
+        src="/images/steps/welcome/04.png"
+        alt="OAuth authorization flow in chat"
+      />
+    </Frame>
+  </Step>
+  <Step title="Start working">
+    Your AI assistant can now access your tools - all within the Nexus interface
+    <Frame caption="AI using your connected tools">
+      <img
+        className="rounded-lg"
+        src="/images/steps/welcome/05.png"
+        alt="AI assistant showing results from connected tools"
+      />
+    </Frame>
+  </Step>
+</Steps>
 
-Sign up for Civic Auth in less than a minute at [auth.civic.com](https://auth.civic.com) to get your Client ID.
+### Optional: Connect External AI Clients
 
-<Frame caption="Civic Auth: Admin Dashboard - Integration Steps">
-  ![](/images/image-2.png)
-</Frame>
+Once you've tested in Nexus chat, you can connect external clients like Claude and development tools for convenience.
 
-Install the library in your app.
-
-<CodeGroup>
-
-```npm npm
-npm install @civic/auth
-```
-
-
-```yarn yarn
-yarn add @civic/auth
-```
-
-
-```pnpm pnpm
-pnpm install @civic/auth
-```
-
-
-```bun bun
-bun add @civic/auth
-```
-
-
-```python pip
-pip install civic-auth
-```
-
-```python uv
-uv add civic-auth
-```
-
-</CodeGroup>
-
-## Web3 Wallets
-
-If you plan to offer your users [Web3 wallets](#web3-wallets), you can use the Civic Auth Web3 SDK.
-
-<Frame caption="Civic Auth: Admin Dashboard - Web3 Wallets Support">
-  ![](/images/image-3.png)
-</Frame>
-
-This SDK extends the functionality of the base Civic Auth SDK to add Web3 features.
-
-<CodeGroup>
-
-```npm-1 npm
-npm install @civic/auth-web3
-```
-
-
-```yarn-1 yarn
-yarn add @civic/auth-web3
-```
-
-
-```pnpm-1 pnpm
-pnpm install @civic/auth-web3
-```
-
-
-```bun-1 bun
-bun add @civic/auth-web3
-```
-
-</CodeGroup>
-
-### Usage
-
-Choose your framework for instructions on how to integrate Civic Auth into your application.
+<Note>
+**No server management, no API keys to juggle, no complex configurations.**
+</Note>
 
 <CardGroup cols={3}>
-  <Card href="/integration/react" img="/images/image-4.png">
-    React
+  <Card title="Claude Desktop" icon="desktop" href="/nexus/quickstart/clients/claude-desktop">
+    **2 minutes** - Most popular AI client
   </Card>
-  <Card href="/integration/nextjs" img="/images/image-5.jpeg">
-    Next.JS
+  <Card title="VS Code" icon="code" href="/nexus/quickstart/clients/vscode">
+    **2 minutes** - Development IDE integration
   </Card>
-  <Card href="/integration/vanillajs" img="/images/image-8.png">
-    Vanilla JavaScript
-  </Card>
-  <Card href="/integration/nodejs" img="/images/image-6.png">
-    Node.JS
-  </Card>
-  <Card href="/integration/python" img="/images/image-7.png">
-    Python
-  </Card>
-  <Card href="/integration/mobile/react-native" img="/images/image-4.png">
-    React Native
+  <Card title="Cursor" icon="cursor-click" href="/nexus/quickstart/clients/cursor">
+    **2 minutes** - AI-powered code editor
   </Card>
 </CardGroup>
 
-For integrating in other environments using any OIDC or OAuth 2.0-compliant client libraries, see [here](/integration/other).
+## Ready to Get Started?
 
-### Civic Auth Demo
+<CardGroup cols={2}>
+  <Card title="Try Nexus Chat Now" icon="sparkles" href="https://nexus.civic.com">
+    **Fastest way** - No setup required, start using tools immediately
+  </Card>
+  <Card title="Connect Your AI Client" icon="plug" href="/nexus/quickstart">
+    **For convenience** - Use ChatGPT, Claude, or development tools
+  </Card>
+</CardGroup>
 
-Don't take our word for it. See Civic Auth in action:
+<Note>
+**Start with Nexus chat first** - Test all tools directly in our interface, then optionally connect external AI clients for convenience.
+</Note>
 
-<Frame>
-  <iframe width="100%" height="420" src="https://www.youtube.com/embed/0VqK56JqIL0" title="Demo - Civic Auth for seamless user management" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen />
-</Frame>
+## What You Can Do
+
+Once connected, your AI can work with all your tools:
+
+<Tabs>
+  <Tab title="For Developers">
+    ```
+    "Check my open GitHub pull requests"
+    "Create an issue for the login bug with debugging details"
+    "Send a Slack message when the deployment finishes"
+    ```
+  </Tab>
+  <Tab title="For Teams">
+    ```
+    "Summarize today's Slack messages in #general"
+    "Create a report from our PostgreSQL sales data"
+    "Find all files updated in Dropbox this week"
+    ```
+  </Tab>
+  <Tab title="For Marketing">
+    ```
+    "Update our ActiveCampaign email list with new signups"
+    "Create HubSpot contact records from this lead sheet"
+    "Send campaign performance data to our Slack marketing channel"
+    "Generate a report of this month's Mailchimp engagement metrics"
+    ```
+  </Tab>
+  <Tab title="For RevOps">
+    ```
+    "Sync CRM data with our HubSpot revenue tracking"
+    "Create Linear tickets for sales process improvements"
+    "Update Airtable with quarterly pipeline metrics"
+    "Send weekly revenue summary to #revenue-ops Slack"
+    ```
+  </Tab>
+</Tabs>
+
+## Organize Tools with Toolkits
+
+Create focused groups of tools for specific workflows instead of overwhelming your AI with every available service.
+
+<Note>
+**Why toolkits matter:** When AI assistants have access to too many tools at once, they often choose the wrong ones or get confused. Toolkits solve this by creating focused, task-specific tool groups.
+</Note>
+
+<CardGroup cols={2}>
+  <Card title="Marketing Analytics" icon="chart-bar">
+    **Google Analytics + Notion + Slack** for pulling data, documenting insights, and sharing reports
+  </Card>
+  <Card title="Developer Debugging" icon="bug">
+    **GitHub + PostgreSQL + Notion** for investigating issues, querying databases, and documenting solutions
+  </Card>
+</CardGroup>
+
+<Card title="Learn About Toolkits" icon="toolbox" href="/nexus/concepts/toolkits">
+  Create focused tool groups that help your AI work more effectively on specific tasks
+</Card>
+
+## Security
+
+<Note>
+  Your data security is our top priority. Civic Nexus is designed for more secure infrastructure with encrypted credential management and proactive server security reviews.
+</Note>
+
+🔒 **Secure by Design** - All tokens encrypted, automatic refresh, stringent infrastructure  
+⚡ **Full Control** - Revoke app access instantly, changes apply immediately  
+🛡️ **Encrypted Ease of Development** - Streamlined development with stringent security standards
+
+<Card title="Security Details" icon="shield-check" href="/nexus/reference/security">
+  Learn about our security architecture, compliance, and best practices
+</Card>
+
+## All Supported Clients
+
+### Primary AI Assistants
+<CardGroup cols={3}>
+  <Card title="Claude Desktop" icon="desktop" href="/nexus/quickstart/clients/claude-desktop">
+    **Available** • Direct connector • 2 mins
+  </Card>
+  <Card title="Claude.ai" icon="globe" href="/nexus/quickstart/clients/claude-web">
+    **Available** • Direct connector • 2 mins
+  </Card>
+  <Card title="Mistral LeChat" icon="sparkles" href="/nexus/quickstart/clients/mistral-lechat">
+    **Available** • Direct connector • 2 mins
+  </Card>
+</CardGroup>
+
+### Development Tools
+<Card title="Developer Setup Guide" icon="code" href="/nexus/developers/client-setup">
+  **Cursor, VS Code, JetBrains IDEs, and more** - Advanced setup guides for development environments
+</Card>
+
+<Info>
+**Primary vs Development:** Primary clients offer simple direct connector setup. Development tools require Hub Bridge configuration but offer the same functionality.
+</Info>
+
+## Get Started Right Now
+
+<Card title="Try Nexus Chat Instantly" icon="rocket" href="https://nexus.civic.com">
+  **Zero setup required** - Sign up and start using hundreds of tools in our built-in chat interface
+</Card>
+
+<Card title="Or Connect External Clients" icon="plug" href="/nexus/quickstart">
+  Step-by-step guides for ChatGPT, Claude, VS Code, and more
+</Card>
+
+## Available Tools & Services
+
+Connect to dozens of popular MCP servers with hundreds of tools:
+
+<CardGroup cols={2}>
+  <Card title="GitHub" icon="server" href="/nexus/reference/servers/github">
+    Manage repos, create issues, review PRs
+  </Card>
+  <Card title="Slack" icon="server" href="/nexus/reference/servers/slack">
+    Send messages, search conversations
+  </Card>
+  <Card title="Dropbox" icon="server" href="/nexus/reference/servers/dropbox">
+    Access files, upload documents
+  </Card>
+  <Card title="Notion" icon="server" href="/nexus/reference/servers/notion">
+    Manage databases, create pages
+  </Card>
+</CardGroup>
+
+**Plus:** ActiveCampaign, PostgreSQL, HubSpot, Airtable, Linear, and many more.
+
+<Card title="Browse All Available Tools" icon="server" href="/nexus/reference/servers">
+  Complete directory of MCP servers with setup guides
+</Card>
+
+## Need Help?
+
+<CardGroup cols={2}>
+  <Card title="Troubleshooting" icon="wrench" href="/nexus/troubleshooting">
+    Common setup issues and solutions
+  </Card>
+  <Card title="Contact Support" icon="slack" href="https://join.slack.com/t/civic-developers/shared_invite/zt-37tv9fyo7-aDT43mUjOFQwdQFmfZLTRw">
+    Get help with your specific setup
+  </Card>
+</CardGroup>
+


### PR DESCRIPTION
Changes:
- Reordered tabs: Nexus → Auth → Labs (Nexus is now first)
- Moved auth content from index.mdx to auth/index.mdx
- Made nexus/overview.mdx the new root index.mdx
- Updated navbar button: 'Try Auth' → 'Try Nexus'
- Button links to https://nexus.civic.com
- Updated all navigation references in docs.json

Nexus is now the landing page and primary product showcase.
