### PR TITLE
docs: add release notes for Auth Server v1.2.18

### DIFF
--- a/overview/changelog.mdx
+++ b/overview/changelog.mdx
@@ -10,7 +10,7 @@ public: true
 **Improvements**
 - Added support for `mcp:tools` scope in Dynamic Client Registration, enabling MCP tool authorization through the `/reg` endpoint
 
-**Bug fixes**
+**Security**
 - Addressed security vulnerabilities to improve platform safety
 
 </Update>


### PR DESCRIPTION
## Summary
- Added changelog entry for Auth Server v1.2.18
- Documents `mcp:tools` scope support in Dynamic Client Registration
- Notes security vulnerability fixes