### PR TITLE
fix: update IDE page URL to point to MCP install page

### DIFF
--- a/nexus/developers/client-setup.mdx
+++ b/nexus/developers/client-setup.mdx
@@ -31,7 +31,7 @@ All development tools require:
 
 <Steps>
   <Step title="Get MCP URL">
-    Visit [nexus.civic.com](https://nexus.civic.com) and copy your personal MCP endpoint URL
+    Visit [nexus.civic.com](https://nexus.civic.com/web/install) and copy your personal MCP endpoint URL
   </Step>
   <Step title="Configure Client">
     Add the HTTP endpoint directly to your development tool's MCP configuration


### PR DESCRIPTION
The link on the IDE setup page now correctly points to
nexus.civic.com/web/install where users can copy their
MCP endpoint URL, instead of the landing page.

https://claude.ai/code/session_01VVXz18J6DozwULar4RDFky