### PR TITLE
docs: change OpenClaw page icon from crab to lobster

### DIFF
--- a/nexus/quickstart/clients/openclaw.mdx
+++ b/nexus/quickstart/clients/openclaw.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenClaw Setup"
 description: "Control OpenClaw's cloud API access via Civic Nexus MCP Gateway"
-icon: "crab"
+icon: "lobster"
 ---
 
 <Callout icon="shield-check" color="green">


### PR DESCRIPTION
## Summary
- Updated the OpenClaw Setup page icon from `crab` to `lobster`

## Test plan
- [ ] Verify the lobster icon renders correctly on the OpenClaw Setup page

🤖 Generated with [Claude Code](https://claude.com/claude-code)