### PR TITLE
CSO-172 Add guide for converting personal account to organization

### DIFF
--- a/nexus/billing.mdx
+++ b/nexus/billing.mdx
@@ -127,6 +127,34 @@ Go to **Billing** > **"Manage Billing"** in the Stripe portal. Your access conti
 
 ---
 
+## Converting Your Account
+
+### Personal to Organization Account
+
+If you want to convert your Personal Nexus account to an Organization account, follow these steps:
+
+1. Click on your profile name in the bottom left corner of the screen
+2. Go to **Settings**
+3. Go to **Members**
+4. Click the **"Convert to organization"** button
+5. Choose your organization name in the modal and click **"Convert to organization"** to complete
+6. You should see an "Account converted to organization successfully" message
+
+<Warning>
+**Important Notes:**
+- Once you've converted your personal account to an organization, **this change is permanent**
+- You cannot have both a Personal account and an Organization account associated with the same email address
+- Only one account type is allowed per email address
+- If you have an Organization account, you cannot convert it back to a personal account
+- To use a personal account after converting to an organization, you'll need to create a separate personal account using a different email address
+</Warning>
+
+<Note>
+If you encounter any issues converting your account, please reach out to our support team via email at [support@civic.com](mailto:support@civic.com) using the email address associated with your account. Include a description of your issue, any troubleshooting steps you've tried, and provide screenshots or a screen recording if possible.
+</Note>
+
+---
+
 ## FAQ
 
 <AccordionGroup>
@@ -144,6 +172,10 @@ Go to **Billing** > **"Manage Billing"** in the Stripe portal. Your access conti
 
   <Accordion title="Can I get a refund?">
     We offer refunds on a case-by-case basis within 7 days of purchase. Contact us at [bd@civic.com](mailto:bd@civic.com).
+  </Accordion>
+  
+  <Accordion title="Can I convert my organization account back to a personal account?">
+    No, converting from a personal account to an organization account is permanent and cannot be reversed. If you need a personal account after converting to an organization, you'll need to create a new personal account using a different email address.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Fixes: https://civicteam.atlassian.net/browse/CSO-172

## Changes
Added a comprehensive "Converting Your Account" section to the billing documentation that explains how users can convert their personal Nexus account to an organization account.

## What's Included
- **Step-by-step conversion instructions**: Clear 6-step process with UI navigation
- **Warning callout**: Highlights that the conversion is permanent and cannot be reversed
- **Important notes**: 
  - One account type per email address
  - No conversion back to personal account
  - Need different email for separate personal account
- **Support information**: Contact details for users who encounter issues
- **New FAQ item**: Addresses the common question about reversing the conversion

## Context
This addresses a documentation gap identified in support queries where users asked "how do I convert my personal account to an organization?" The existing documentation only mentioned that both account types exist but didn't explain the conversion process.

## Source
From Kapa Analysis review - Row 25 of Support Queries Review sheet (week of Jan 20-25, 2026)

/cc @Naledi-Civic