### PR TITLE
docs: add missing changelog entries for Feb 2026 releases

### DIFF
--- a/overview/changelog.mdx
+++ b/overview/changelog.mdx
@@ -5,6 +5,36 @@ icon: "pen"
 public: true
 ---
 
+<Update label="February 13, 2026" description="Auth Server v1.2.21">
+
+**Bug Fixes**
+- Fixed federated token exchange `sub` claim to use the correct account identifier
+- Fixed federated token exchange userinfo endpoint to return proper OIDC claims
+- Extracted standard OIDC claims (name, email, picture, etc.) from external tokens during federated token exchange
+
+**Security**
+- Dependency upgrade to address a high-severity vulnerability
+
+</Update>
+
+<Update label="February 9, 2026" description="Auth Server v1.2.20">
+
+**Improvements**
+- Internal infrastructure and analytics improvements
+
+</Update>
+
+<Update label="February 9, 2026" description="Apps v0.2.82">
+
+**Improvements**
+- Next.js 16 compatibility updates
+
+**Bug Fixes**
+- Fixed SSR hydration mismatches in useUser hook and login app
+- Fixed cross-origin SecurityError in MessageHandler logging
+
+</Update>
+
 <Update label="February 4, 2026" description="Auth Server v1.2.19">
 
 **Security**


### PR DESCRIPTION
## Summary
- Added changelog entry for Auth Server v1.2.21 (Feb 13) — federated token exchange fixes and security patch
- Added changelog entry for Auth Server v1.2.20 (Feb 9) — internal infrastructure improvements
- Added changelog entry for Apps v0.2.82 (Feb 9) — Next.js 16 compatibility and SSR hydration fixes