### PR TITLE
[CSO-374] FAQs - Add signatures explanation

### DIFF
--- a/overview/faqs.mdx
+++ b/overview/faqs.mdx
@@ -213,6 +213,8 @@ If you're experiencing any issues integrating Civic Auth, follow the troubleshoo
 
     1. When logging in with Civic, the signatures of the auth tokens are verified against Civic's JWKS public key to prove they come from Civic.
     2. When using Civic's Web3 features, the user is asked to sign blockchain transactions or messages using an email code and a non-custodial wallet private key, to prove they authorised the transaction.
+
+  </Accordion>
   <Accordion title="Does Civic Auth support multi-factor authentication (MFA)?">
 
     MFA is not currently supported by Civic Auth. Authentication is handled via passkeys, email magic links, and social login providers (Google, Apple, X, etc.). These methods are inherently phishing-resistant and do not require a separate MFA step.


### PR DESCRIPTION
## Summary
Adds a new FAQ entry explaining what "signatures" means in the context of Civic Auth.

## Changes
- `overview/faqs.mdx`: Added "What are 'signatures' in Civic Auth?" accordion entry

## Jira
[CSO-374](https://civicteam.atlassian.net/browse/CSO-374)

## Context
The support bot gave confused or inconsistent answers when users asked about signatures. This entry clarifies both the auth token verification and Web3 transaction signing contexts.

[CSO-374]: https://civicteam.atlassian.net/browse/CSO-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ