### PR TITLE
CSO-490: Update OpenClaw ClawHub skill path to civictechuser/openclaw-civic-skill

### DIFF
--- a/civic/quickstart/clients/openclaw.mdx
+++ b/civic/quickstart/clients/openclaw.mdx
@@ -79,12 +79,12 @@ When using OpenClaw with Civic, you must also:
 For the best experience, install the official Civic skill from ClawHub:
 
 ```bash
-clawhub install civic
+clawhub install civictechuser/openclaw-civic-skill
 ```
 
-Or visit the skill page directly:
+Or visit the skill page directly and download the .zip file to give to your agent:
 
-<Card title="Civic Skill" icon="download" href="https://clawhub.ai/TYRONEMICHAEL/civic">
+<Card title="Civic Skill" icon="download" href="https://clawhub.ai/civictechuser/openclaw-civic-skill">
   Install the official Civic skill for OpenClaw
 </Card>
 


### PR DESCRIPTION
## Summary

Updates the OpenClaw setup guide to point to the correct ClawHub skill path, as confirmed by Titus in CSO-490 (PR Ready ✅).

### Changes
- `clawhub install civic` → `clawhub install civictechuser/openclaw-civic-skill`
- Card href updated: `https://clawhub.ai/TYRONEMICHAEL/civic` → `https://clawhub.ai/civictechuser/openclaw-civic-skill`
- Card description updated: "Or visit the skill page directly and download the .zip file to give to your agent:"

### Context
The rebrand PR (#580) had already renamed the path from `civic-nexus` → `civic`. Brad Webb asked whether the path should be updated to `openclaw-civic-skill`, and Titus confirmed: "yes. I updated the ticket content with the new link" → PR Ready.

Jira: [CSO-490](https://civic.atlassian.net/browse/CSO-490)

[CSO-490]: https://civicteam.atlassian.net/browse/CSO-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ