### PR TITLE
docs: add strict mode warning to OpenAI and native integration pages (NEXUS-1525)

### DIFF
--- a/civic/developers/native-integration/index.mdx
+++ b/civic/developers/native-integration/index.mdx
@@ -10,6 +10,12 @@ Civic can be integrated natively into third-party applications — MCP clients, 
 
 A native integration embeds Civic capabilities directly into your application's runtime. Instead of relying on the LLM to surface authorization links and wait for manual user action, your application can intercept these flows, handle them programmatically, and return results transparently.
 
+## OpenAI Strict Mode
+
+<Warning>
+Not all Civic tool schemas are compatible with OpenAI's [`strict: true` structured outputs](https://developers.openai.com/api/docs/guides/structured-outputs). If using the Responses API, ensure `strict` is set to `false` when calling Civic tools.
+</Warning>
+
 ## Available integration guides
 
 <CardGroup cols={1}>

--- a/civic/recipes/openai-agents.mdx
+++ b/civic/recipes/openai-agents.mdx
@@ -231,6 +231,12 @@ const agent = new Agent({
 });
 ```
 
+## Strict Mode
+
+<Warning>
+Not all Civic tool schemas are compatible with OpenAI's [`strict: true` structured outputs](https://developers.openai.com/api/docs/guides/structured-outputs). Ensure `strict` is set to `false` on the Responses API when using Civic tools.
+</Warning>
+
 ## Key Advantages
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary
- Add `strict: false` warning for OpenAI's structured outputs to the OpenAI Agents SDK and Native Integration pages
- Not all Civic tool schemas are compatible with `strict: true` on the Responses API

## Test plan
- [x] Verify warning renders correctly on both pages
- [x] Confirm links to OpenAI structured outputs docs resolve