### PR TITLE
NEXUS-1534: rename token exchange params to civic_profile/civic_account

### DIFF
--- a/civic/developers/native-integration/authorization.mdx
+++ b/civic/developers/native-integration/authorization.mdx
@@ -75,8 +75,8 @@ You have two options depending on your architecture:
 
     | Parameter | Description |
     |-----------|-------------|
-    | `nexus_account` | Account identifier to include as a claim in the exchanged token. |
-    | `nexus_profile` | Profile (toolkit) identifier to include as a claim in the exchanged token. |
+    | `civic_account` | Account identifier to include as a claim in the exchanged token. |
+    | `civic_profile` | Profile (toolkit) identifier to include as a claim in the exchanged token. |
 
     Since a linked Civic Auth organization is already scoped to the account by default (via the Client ID), these parameters are primarily useful for restricting access to a **specific profile or toolkit** within the account — for example, limiting a user or agent to a single toolkit rather than the entire organization.
   </Tab>


### PR DESCRIPTION
## Summary
- Renamed `nexus_profile` → `civic_profile` and `nexus_account` → `civic_account` in token exchange documentation to match updated system naming.

## Test plan
- [ ] Verify docs render correctly on preview