### PR TITLE
NEXUS-1573: Update token page refs to Install → MCP URL

### DIFF
--- a/civic/concepts/secret-management.mdx
+++ b/civic/concepts/secret-management.mdx
@@ -100,7 +100,7 @@ Used by: Custom internal services, any HTTP service that uses `Authorization: Be
 |---|---|
 | OAuth tokens | Auto-refreshed by Civic before expiry. No action needed. |
 | API keys | Manual. Update in the server settings when you rotate the key. |
-| Civic tokens (for agent auth) | Expire after 30 days. Regenerate from Settings → Tokens. |
+| Civic tokens (for agent auth) | Expire after 30 days. Regenerate from [Install → MCP URL](https://app.civic.com/web/install/mcp-url). |
 
 ## What Happens on Revocation
 

--- a/civic/recipes/deepagents.mdx
+++ b/civic/recipes/deepagents.mdx
@@ -10,7 +10,7 @@ Connect a [DeepAgents](https://github.com/titus-civic/deepagents-reference-imple
 
 - Python 3.11+
 - A Civic account at [app.civic.com](https://app.civic.com) with a configured toolkit
-- A Civic token (generate from Settings → Tokens)
+- A Civic token (generate from [Install → MCP URL](https://app.civic.com/web/install/mcp-url))
 - An Anthropic API key
 
 ## Installation
@@ -33,7 +33,7 @@ pip install deepagents langchain-mcp-adapters langchain-anthropic fastapi uvicor
 # Your full Civic toolkit URL (include profile param for production agents)
 CIVIC_URL=https://app.civic.com/hub/mcp?profile=your-toolkit&lock=true
 
-# Civic token generated from app.civic.com → Settings → Tokens
+# Civic token generated from app.civic.com → Install → MCP URL
 CIVIC_TOKEN=your-civic-token
 
 # Anthropic API key
@@ -143,7 +143,7 @@ CIVIC_URL=https://app.civic.com/hub/mcp?profile=support&skills=escalation,canned
 | Variable | Description |
 |---|---|
 | `CIVIC_URL` | Full Civic toolkit URL including profile and any URL parameters |
-| `CIVIC_TOKEN` | Civic token from app.civic.com → Settings → Tokens |
+| `CIVIC_TOKEN` | Civic token from [app.civic.com → Install → MCP URL](https://app.civic.com/web/install/mcp-url) |
 | `ANTHROPIC_API_KEY` | Anthropic API key for the Claude model |
 
 ## Reference Implementation

--- a/civic/recipes/langchain.mdx
+++ b/civic/recipes/langchain.mdx
@@ -10,7 +10,7 @@ Connect a LangGraph agent to Civic using the `langchain-mcp-adapters` package, w
 
 - Python 3.11+
 - A Civic account at [app.civic.com](https://app.civic.com) with a configured toolkit
-- A Civic token (generate from Settings → Tokens)
+- A Civic token (generate from [Install → MCP URL](https://app.civic.com/web/install/mcp-url))
 - An LLM API key (e.g. Anthropic)
 
 ## Installation
@@ -25,7 +25,7 @@ pip install langgraph langchain-anthropic langchain-mcp-adapters
 # Your full Civic toolkit URL (include profile param for production agents)
 CIVIC_URL=https://app.civic.com/hub/mcp?profile=your-toolkit
 
-# Civic token generated from app.civic.com → Settings → Tokens
+# Civic token generated from app.civic.com → Install → MCP URL
 CIVIC_TOKEN=your-civic-token
 
 # Your LLM provider key
@@ -125,7 +125,7 @@ CIVIC_URL=https://app.civic.com/hub/mcp?profile=support&skills=escalation,canned
 | Variable | Description |
 |---|---|
 | `CIVIC_URL` | Full Civic toolkit URL including profile and any URL parameters |
-| `CIVIC_TOKEN` | Civic token from app.civic.com → Settings → Tokens |
+| `CIVIC_TOKEN` | Civic token from [app.civic.com → Install → MCP URL](https://app.civic.com/web/install/mcp-url) |
 
 ## Reference Implementation
 

--- a/snippets/_auth-method-callout.mdx
+++ b/snippets/_auth-method-callout.mdx
@@ -6,7 +6,7 @@ Civic supports two methods depending on how your client connects:
 | Client type | Method | How it works |
 |---|---|---|
 | Interactive clients (Claude Desktop, Cursor, VS Code, Gemini CLI, Goose, Windsurf) | **OAuth** | When you connect, your client opens a browser window to app.civic.com. Sign in once — no manual token needed. |
-| Automated agents (LangChain, custom scripts, OpenAI SDK, Anthropic SDK) | **Civic Token** | Generate a bearer token at app.civic.com → Settings → Tokens. Pass it as an `Authorization: Bearer` header. |
+| Automated agents (LangChain, custom scripts, OpenAI SDK, Anthropic SDK) | **Civic Token** | Generate a bearer token at [app.civic.com → Install → MCP URL](https://app.civic.com/web/install/mcp-url). Pass it as an `Authorization: Bearer` header. |
 
 See [Get Your Credentials](/civic/quickstart/credentials) for full details.
 </Note>

--- a/snippets/_civic-token-env-setup.mdx
+++ b/snippets/_civic-token-env-setup.mdx
@@ -2,7 +2,7 @@
 
 1. Log in to [app.civic.com](https://app.civic.com)
 2. Click your account name in the bottom left
-3. Go to **Settings → Tokens**
+3. Go to **[Install → MCP URL](https://app.civic.com/web/install/mcp-url)**
 4. Click **Generate Token** and copy it immediately — it won't be shown again
 
 <Warning>


### PR DESCRIPTION
## Summary
- Rename all "Settings → Tokens" references to "Install → MCP URL" (the actual page name)
- Add deep links to `https://app.civic.com/web/install/mcp-url` across 5 files

## Files changed
- `snippets/_civic-token-env-setup.mdx` — token generation instructions
- `snippets/_auth-method-callout.mdx` — auth method comparison table
- `civic/recipes/langchain.mdx` — prerequisites, env vars, env var reference table
- `civic/recipes/deepagents.mdx` — prerequisites, env vars, env var reference table
- `civic/concepts/secret-management.mdx` — credential rotation table

## Test plan
- [ ] Verify `https://app.civic.com/web/install/mcp-url` resolves correctly
- [ ] Check rendered markdown links in tables and inline text

🤖 Generated with [Claude Code](https://claude.com/claude-code)