### PR TITLE
Fix CivicMcpClient snippets and profile ID references

### DIFF
--- a/civic/recipes/civic-mcp-client-python.mdx
+++ b/civic/recipes/civic-mcp-client-python.mdx
@@ -49,7 +49,7 @@ pip install "civic-mcp-client[langchain,pydanticai,fastmcp]"
 CIVIC_TOKEN=your-civic-token-here
 
 # Optional: lock tool access to a specific profile id
-CIVIC_PROFILE_ID=your-profile-uuid
+CIVIC_PROFILE_ID=optional-profile-id
 ```
 
 ```python
@@ -58,7 +58,7 @@ from civic_mcp_client import CivicMCPClient
 client = CivicMCPClient(
     # Use your token loading approach (env vars, secrets manager, etc.)
     auth={"token": "your-civic-token-here"},
-    civic_profile="your-profile-uuid",
+    civic_profile="optional-profile-id",
 )
 ```
 
@@ -72,7 +72,7 @@ CIVIC_CLIENT_ID=your_client_id
 CIVIC_CLIENT_SECRET=your_client_secret
 
 # Optional: lock tool access to a specific profile id
-CIVIC_PROFILE_ID=your-profile-uuid
+CIVIC_PROFILE_ID=optional-profile-id
 ```
 
 ```python
@@ -92,7 +92,7 @@ client = CivicMCPClient(
             "expires_in": 3600,  # optional requested lifetime in seconds
         }
     },
-    civic_profile="your-profile-uuid",
+    civic_profile="optional-profile-id",
 )
 ```
 
@@ -108,7 +108,7 @@ from civic_mcp_client import CivicMCPClient
 async def main() -> None:
     client = CivicMCPClient(
         auth={"token": "your-civic-token-here"},
-        civic_profile="your-profile-uuid",
+        civic_profile="optional-profile-id",
     )
 
     # Discover available tools from your configured toolkit


### PR DESCRIPTION
## Summary
- **Civic Auth snippet**: `getUser()` / `idToken` → `getTokens()` / `accessToken`
- **Token exchange snippet**: `civicProfile: "default"` → `process.env.CIVIC_PROFILE_ID` (UUID)
- **Header**: `x-civic-profile` → `x-civic-profile-id` with UUID placeholder
- **Token exchange docs**: clarified `civic_profile` is a Profile ID (UUID)

## Test plan
- [ ] Verify code snippets render correctly in Mintlify preview
- [ ] Confirm `getTokens` / `accessToken` matches `@civic/auth` SDK

NEXUS-1794