### PR TITLE
docs: combined release notes for apps-0.2.90, v0.1.119–v0.1.121

### DIFF
--- a/civic/changelog.mdx
+++ b/civic/changelog.mdx
@@ -5,6 +5,48 @@ icon: "pen"
 public: true
 ---
 
+<Update label="March 23, 2026" description="v0.1.121">
+
+**Features**
+- Added Bodyguard prompt injection detection to help protect against malicious inputs
+- Constraint approval mode is now configurable per profile, giving you more control over how constraints are evaluated
+- You can now edit token exchange provider configurations after creation
+- Localhost URLs are now supported for token exchange issuers, making local development easier
+- Added Manus agent to the onboarding flow for faster setup
+- Operators can now override individual constraints directly
+
+**Improvements**
+- Improved loading experience on the Skills landing page
+- Upgraded markdown rendering for better chat display
+
+**Bug fixes**
+- Fixed an issue where some server connections required a manual reconnect
+- Fixed duplicate invite attempts returning a generic error instead of a helpful message
+- Users with canceled subscriptions now correctly see the upgrade option
+- Fixed issues with the onboarding flow
+- Resolved a security vulnerability in a core dependency
+
+</Update>
+
+<Update label="March 20, 2026" description="v0.1.120">
+
+**Bug fixes**
+- Fixed an issue where users could incorrectly gain access to public accounts when signing in with a different Civic Auth application
+
+</Update>
+
+<Update label="March 19, 2026" description="v0.1.119">
+
+**Improvements**
+- Updated Civic Auth integration instructions to use the latest authentication method
+- Updated the Civic preview image for improved branding across social shares and link previews
+
+**Bug fixes**
+- Fixed activity table rendering and restored access to the activity view
+- Fixed the authentication path toggle to respond immediately when switched
+
+</Update>
+
 <Update label="March 19, 2026" description="v0.1.118">
 
 **Features**

--- a/overview/changelog.mdx
+++ b/overview/changelog.mdx
@@ -43,6 +43,23 @@ public: true
 
 </Update>
 
+<Update label="March 17, 2026" description="apps-0.2.90">
+
+**Features**
+- Added programmatic account creation API, allowing apps to create Civic Auth accounts automatically via API
+- Added token exchange configuration endpoints for programmatic app setup
+- Added account selector to the dashboard header for users who belong to multiple accounts
+
+**Improvements**
+- Improved authentication reliability and error handling
+- Reduced performance overhead of application monitoring
+
+**Bug fixes**
+- Fixed an issue where account creation could fail due to certain ID formats
+- Fixed a navigation issue that caused incorrect URLs in the dashboard
+
+</Update>
+
 <Update label="March 11, 2026" description="auth-server-1.2.24">
 
 **Features**


### PR DESCRIPTION
## Summary
- Consolidates four open release notes PRs into a single changelog update
- Adds entries in chronological order to both `overview/changelog.mdx` and `civic/changelog.mdx`

### Included PRs
- #629 — Release notes: apps-0.2.90 (March 17)
- #671 — Release notes: v0.1.119 (March 19)
- #675 — Release notes: v0.1.120 (March 20)
- #679 — Release notes: v0.1.121 (March 23)

## Test plan
- [ ] Verify changelog entries render correctly in Mintlify
- [ ] Confirm chronological ordering is correct
- [ ] Close PRs #629, #671, #675, #679 after merge