### PR TITLE
chore(cutover): point deploy CNAME + link-check at docs.civic.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,11 @@
-name: Build & Deploy docs-next
+name: Build & Deploy
 
-# Phase 4 cutover: builds the Docusaurus site and publishes to GitHub Pages at
-# docs-next.civic.com for side-by-side QA with the current Mintlify site. Once
-# DNS is swapped to the Docusaurus deploy, rename the CNAME below to
-# docs.civic.com.
-#
-# During the migration we also deploy from the migration branch so the team
-# can review the running site without merging to main. Drop that branch
-# from this list at cutover.
+# Builds the Docusaurus site and publishes to GitHub Pages at docs.civic.com.
 
 on:
   push:
     branches:
       - main
-      - docs-next
   workflow_dispatch:
 
 permissions:
@@ -42,8 +34,7 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-      # CNAME for the target host. Flip to docs.civic.com at cutover.
-      - run: echo "docs-next.civic.com" > build/CNAME
+      - run: echo "docs.civic.com" > build/CNAME
       - uses: actions/upload-pages-artifact@v3
         with:
           path: build

--- a/.github/workflows/link-check-production.yml
+++ b/.github/workflows/link-check-production.yml
@@ -1,8 +1,6 @@
 name: Link Check (Production)
 
-# Runs against the deployed site URL. Flip the --base value to docs.civic.com
-# at cutover; until then we point at docs-next.civic.com so the check exercises
-# the Docusaurus build without interfering with the Mintlify production site.
+# Runs against the deployed production site URL.
 
 on:
   push:
@@ -30,7 +28,7 @@ jobs:
         with:
           args: >
             --config lychee.toml
-            --base 'https://docs-next.civic.com'
+            --base 'https://docs.civic.com'
             --no-progress
             'build/**/*.html'
           fail: true

--- a/README.md
+++ b/README.md
@@ -94,16 +94,13 @@ Each renders a small HTML redirect file at the source path.
 ## Deployment
 
 `.github/workflows/deploy.yml` builds on every push to `main` and publishes to
-GitHub Pages. The CNAME in the artifact is currently `docs-next.civic.com` for
-side-by-side QA with the Mintlify production site — flip to `docs.civic.com`
-at DNS cutover.
+GitHub Pages at `docs.civic.com` (CNAME written into the artifact).
 
 ## Link checking
 
 `.github/workflows/link-check-branch.yml` builds the site and runs
 [`lychee`](https://github.com/lycheeverse/lychee) against `build/**/*.html` on
-every PR. The production variant runs against
-`https://docs-next.civic.com` daily.
+every PR. The production variant runs against `https://docs.civic.com` daily.
 
 ## Fonts
 


### PR DESCRIPTION
## Summary

Post-merge cutover changes to flip the docs site from `docs-next.civic.com` to `docs.civic.com`:

- **`.github/workflows/deploy.yml`**: CNAME written into the Pages artifact is now `docs.civic.com`. Dropped `docs-next` from the `branches` trigger list, removed the migration-era comments, and renamed the workflow to `Build & Deploy`.
- **`.github/workflows/link-check-production.yml`**: `--base` URL flipped to `https://docs.civic.com`. Removed the "until cutover" comment.
- **`README.md`**: Deployment and Link checking sections updated to describe the production state.

## Required external steps (not in this PR)

These must happen around merging this PR — coordinate so the GitHub Pages domain, DNS, and the CNAME written by this workflow all agree:

1. **GitHub Pages settings** (`Settings → Pages`): change custom domain from `docs-next.civic.com` to `docs.civic.com`, re-verify, let HTTPS cert re-provision.
2. **DNS**: repoint `docs.civic.com` CNAME from Mintlify to `civicteam.github.io`.
3. **Mintlify**: revoke the GitHub App (`github.com/organizations/civicteam/settings/installations`) and archive the project in the Mintlify dashboard.
4. Once traffic is flowing to GitHub Pages, remove the `docs-next.civic.com` DNS record.

## Test plan

- [ ] Merge this PR and confirm the `Build & Deploy` workflow succeeds.
- [ ] After DNS + Pages settings are flipped, confirm `https://docs.civic.com` serves the Docusaurus site.
- [ ] Confirm the next scheduled `Link Check (Production)` run (daily at 09:00 UTC) passes against `https://docs.civic.com`.