### PR TITLE
fix(links): correct n8n sample workflow path in mcp-hub docs

### DIFF
--- a/docs/labs/private/mcp-hub.mdx
+++ b/docs/labs/private/mcp-hub.mdx
@@ -147,7 +147,7 @@ Build AI-powered workflows with n8n and Civic Labs.
 
 #### Prerequisites
 
-1. [Import the example workflow](https://github.com/civicteam/docs.civic.com/blob/main/labs/n8n_sample_api-key-flow.json) into your n8n instance
+1. [Import the example workflow](https://github.com/civicteam/docs.civic.com/blob/main/docs/labs/n8n_sample_api-key-flow.json) into your n8n instance
 2. Configure your AWS Bedrock credentials in n8n (or use another AI model)
 3. [Contact us](https://civickey.typeform.com/to/uVH7CWJ5) to obtain an API key for the MCP Hub
 


### PR DESCRIPTION
## Summary
- Fix broken link in `docs/labs/private/mcp-hub.mdx` pointing to `main/labs/n8n_sample_api-key-flow.json` (404). The file actually lives at `docs/labs/n8n_sample_api-key-flow.json` after the Docusaurus migration.
- This was the sole link-check failure blocking unrelated PRs like #816.

## Test plan
- [ ] CI link-check passes
- [ ] Resolved URL renders the JSON file in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)