### PR TITLE
fix(recipes): correct adapter usage after source code verification

### DIFF
--- a/docs/civic/recipes/deepagents.mdx
+++ b/docs/civic/recipes/deepagents.mdx
@@ -5,7 +5,7 @@ sidebar_custom_props:
   icon: "code"
 ---
 
-Connect a [DeepAgents](https://github.com/civicteam/deepagents-reference-implementation-civic) agent to Civic using `civic-mcp-client` with the built-in LangChain adapter, which exposes Civic's MCP tools as `DynamicStructuredTool` instances compatible with DeepAgents.
+Connect a [DeepAgents](https://github.com/civicteam/deepagents-reference-implementation-civic) agent to Civic using `langchain-mcp-adapters`, which bridges DeepAgents' tool interface with Civic's Streamable HTTP MCP transport.
 
 ## Prerequisites
 
@@ -19,13 +19,13 @@ Connect a [DeepAgents](https://github.com/civicteam/deepagents-reference-impleme
 Using [uv](https://docs.astral.sh/uv/) (recommended):
 
 ```bash
-uv add deepagents "civic-mcp-client[langchain]" langchain-anthropic fastapi uvicorn python-dotenv
+uv add deepagents langchain-mcp-adapters langchain-anthropic fastapi uvicorn python-dotenv
 ```
 
 Or with pip:
 
 ```bash
-pip install deepagents "civic-mcp-client[langchain]" langchain-anthropic fastapi uvicorn python-dotenv
+pip install deepagents langchain-mcp-adapters langchain-anthropic fastapi uvicorn python-dotenv
 ```
 
 ## Environment Variables
@@ -44,15 +44,14 @@ ANTHROPIC_API_KEY=your-anthropic-key   # or OPENAI_API_KEY, etc.
 
 ## Connecting to Civic
 
-Use `CivicMCPClient` with the `langchain()` adapter to get tools during app startup, then pass them to `create_deep_agent`:
+Use `MultiServerMCPClient` to connect to the Civic MCP Hub during app startup, then pass the discovered tools to `create_deep_agent`:
 
 ```python
 import os
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from deepagents import create_deep_agent
-from civic_mcp_client import CivicMCPClient
-from civic_mcp_client.adapters.langchain import langchain
+from langchain_mcp_adapters.client import MultiServerMCPClient
 
 mcp_client = None
 agent = None
@@ -61,8 +60,15 @@ agent = None
 async def lifespan(app: FastAPI):
     global mcp_client, agent
 
-    mcp_client = CivicMCPClient(auth={"token": os.environ["CIVIC_TOKEN"]})
-    tools = await mcp_client.adapt_for(langchain())
+    mcp_client = MultiServerMCPClient({
+        "civic-nexus": {
+            "transport": "streamable_http",
+            "url": "https://app.civic.com/hub/mcp",
+            "headers": {"Authorization": f"Bearer {os.environ['CIVIC_TOKEN']}"},
+        }
+    })
+
+    tools = await mcp_client.get_tools()
 
     agent = create_deep_agent(
         model="anthropic:claude-sonnet-4-6",  # or "openai:gpt-4o", etc.
@@ -72,7 +78,7 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    await mcp_client.close()
+    await mcp_client.__aexit__(None, None, None)
 
 app = FastAPI(lifespan=lifespan)
 ```
@@ -106,13 +112,16 @@ uv run uvicorn main:app --reload
 
 ### Lock to a Toolkit
 
-For production agents, scope to a specific toolkit using the `civic_profile` parameter:
+For production agents, scope to a specific toolkit by adding `profile` to the MCP URL:
 
 ```python
-mcp_client = CivicMCPClient(
-    auth={"token": os.environ["CIVIC_TOKEN"]},
-    civic_profile="your-production-profile-id",
-)
+mcp_client = MultiServerMCPClient({
+    "civic-nexus": {
+        "transport": "streamable_http",
+        "url": f"https://app.civic.com/hub/mcp?profile={os.environ['CIVIC_PROFILE_ID']}",
+        "headers": {"Authorization": f"Bearer {os.environ['CIVIC_TOKEN']}"},
+    }
+})
 ```
 
 When a profile is specified, the session is locked by default — the agent cannot switch toolkits or modify its own guardrails. This prevents prompt injection attacks from escaping the defined tool scope.

--- a/docs/civic/recipes/langchain.mdx
+++ b/docs/civic/recipes/langchain.mdx
@@ -1,11 +1,11 @@
 ---
 title: LangChain (Python)
-description: Connect a LangGraph agent to Civic's MCP Hub using civic-mcp-client
+description: Connect a LangChain agent to Civic's MCP Hub using civic-mcp-client
 sidebar_custom_props:
   icon: "python"
 ---
 
-Connect a [LangGraph](https://langchain-ai.github.io/langgraph/) agent to Civic using `civic-mcp-client` with the built-in LangChain adapter. The adapter returns `DynamicStructuredTool` instances ready to use with `create_react_agent`.
+Connect a [LangChain](https://python.langchain.com/) agent to Civic using `civic-mcp-client`. The `langchain()` adapter returns tool schemas ready to bind to any `ChatModel`, with a helper for executing tool calls.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ Connect a [LangGraph](https://langchain-ai.github.io/langgraph/) agent to Civic 
 ## Installation
 
 ```bash
-pip install "civic-mcp-client[langchain]" langchain-anthropic langgraph python-dotenv
+pip install "civic-mcp-client[langchain]" langchain-anthropic python-dotenv
 ```
 
 ## Environment Variables
@@ -32,33 +32,42 @@ ANTHROPIC_API_KEY=your-anthropic-key
 
 ## Connecting to Civic
 
-Use `CivicMCPClient` with the `langchain()` adapter to get `DynamicStructuredTool` instances, then pass them to `create_react_agent`:
+Use `CivicMCPClient` with the `langchain()` adapter to get tool schemas, bind them to a model, then use `execute_langchain_tool_call` to execute tool calls from the model's response:
 
 ```python
 import asyncio
 import os
 from dotenv import load_dotenv
 from civic_mcp_client import CivicMCPClient
-from civic_mcp_client.adapters.langchain import langchain
+from civic_mcp_client.adapters.langchain import execute_langchain_tool_call, langchain
 from langchain_anthropic import ChatAnthropic
-from langgraph.prebuilt import create_react_agent
+from langchain_core.messages import HumanMessage, ToolMessage
 
 load_dotenv()
 
 async def main():
     client = CivicMCPClient(auth={"token": os.environ["CIVIC_TOKEN"]})
-    tools = await client.adapt_for(langchain())
+    tool_schemas = await client.adapt_for(langchain())
 
-    agent = create_react_agent(
-        model=ChatAnthropic(model="claude-sonnet-4-6"),
-        tools=tools,
-    )
+    model = ChatAnthropic(model="claude-sonnet-4-6").bind_tools(tool_schemas)
 
-    result = await agent.ainvoke(
-        {"messages": [{"role": "user", "content": "What events do I have today?"}]}
-    )
-    print(result["messages"][-1].content)
+    messages = [HumanMessage(content="What events do I have today?")]
 
+    while True:
+        response = await model.ainvoke(messages)
+        messages.append(response)
+
+        if not response.tool_calls:
+            break
+
+        for tool_call in response.tool_calls:
+            result = await execute_langchain_tool_call(client, tool_call)
+            messages.append(ToolMessage(
+                content=str(result),
+                tool_call_id=tool_call["id"],
+            ))
+
+    print(messages[-1].content)
     await client.close()
 
 asyncio.run(main())
@@ -73,32 +82,11 @@ For production agents, scope to a specific toolkit:
 ```python
 client = CivicMCPClient(
     auth={"token": os.environ["CIVIC_TOKEN"]},
-    civic_profile="your-production-profile-id",
+    civic_profile=os.environ.get("CIVIC_PROFILE_ID"),
 )
 ```
 
 When a profile is specified, the session is locked by default — the agent cannot switch toolkits or modify its own guardrails. This prevents prompt injection attacks from escaping the defined tool scope.
-
-### Multi-Turn Conversations
-
-Pass a `checkpointer` to `create_react_agent` to retain conversation history across invocations:
-
-```python
-from langgraph.checkpoint.memory import MemorySaver
-
-agent = create_react_agent(
-    model=ChatAnthropic(model="claude-sonnet-4-6"),
-    tools=tools,
-    checkpointer=MemorySaver(),
-)
-
-config = {"configurable": {"thread_id": "session-1"}}
-
-result = await agent.ainvoke(
-    {"messages": [{"role": "user", "content": "What events do I have today?"}]},
-    config,
-)
-```
 
 ## Reference Implementation
 

--- a/docs/civic/recipes/pydantic-ai.mdx
+++ b/docs/civic/recipes/pydantic-ai.mdx
@@ -7,7 +7,7 @@ sidebar_custom_props:
 
 import CivicTokenSetup from '@site/docs/_snippets/_civic-token-env-setup.mdx'
 
-Connect a [Pydantic AI](https://ai.pydantic.dev/) agent to Civic. For standalone scripts, use `civic-mcp-client` with the built-in Pydantic AI adapter. For web apps, use native `MCPServerStreamableHTTP` with per-user Civic Auth tokens.
+Connect a [Pydantic AI](https://ai.pydantic.dev/) agent to Civic. For standalone scripts, use Pydantic AI's native `MCPServerStreamableHTTP` with a Civic token. For web apps, use per-user Civic Auth tokens.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ Connect a [Pydantic AI](https://ai.pydantic.dev/) agent to Civic. For standalone
 ## Installation
 
 ```bash
-pip install "civic-mcp-client[pydanticai]" pydantic-ai python-dotenv
+pip install pydantic-ai python-dotenv
 ```
 
 ## Authentication
@@ -38,21 +38,22 @@ pip install "civic-mcp-client[pydanticai]" pydantic-ai python-dotenv
     import os
     import asyncio
     from dotenv import load_dotenv
-    from civic_mcp_client import CivicMCPClient
-    from civic_mcp_client.adapters.pydanticai import pydanticai
     from pydantic_ai import Agent
+    from pydantic_ai.mcp import MCPServerStreamableHTTP
 
     load_dotenv()
 
+    server = MCPServerStreamableHTTP(
+        "https://app.civic.com/hub/mcp",
+        headers={"Authorization": f"Bearer {os.environ['CIVIC_TOKEN']}"},
+    )
+
+    agent = Agent("anthropic:claude-sonnet-4-6", mcp_servers=[server])
+
     async def main():
-        client = CivicMCPClient(auth={"token": os.environ["CIVIC_TOKEN"]})
-        tools = await client.adapt_for(pydanticai())
-
-        agent = Agent("anthropic:claude-sonnet-4-6", tools=tools)
-        result = await agent.run("List open PRs in civicteam/ai-chatbot")
+        async with agent.run_mcp_servers():
+            result = await agent.run("List open PRs in civicteam/ai-chatbot")
         print(result.output)
-
-        await client.close()
 
     asyncio.run(main())
     ```
@@ -152,12 +153,12 @@ Use `mcp_servers=[server]` — not `toolsets=[server]`. The `mcp_servers` parame
 
 ## Production Configuration
 
-For production agents, scope to a specific toolkit:
+For production agents, lock to a specific toolkit by adding `profile` to the MCP URL:
 
 ```python
-client = CivicMCPClient(
-    auth={"token": os.environ["CIVIC_TOKEN"]},
-    civic_profile="your-production-profile-id",
+server = MCPServerStreamableHTTP(
+    f"https://app.civic.com/hub/mcp?profile={os.environ['CIVIC_PROFILE_ID']}",
+    headers={"Authorization": f"Bearer {os.environ['CIVIC_TOKEN']}"},
 )
 ```
 


### PR DESCRIPTION
## Summary

- **langchain.mdx**: Replaces `create_react_agent` with the correct manual tool loop (`bind_tools` + `execute_langchain_tool_call`). The Python `langchain()` adapter in `civic-mcp-client` returns raw OpenAI-style function schemas, not `DynamicStructuredTool` instances, so `create_react_agent` would fail at tool execution time.
- **pydantic-ai.mdx**: Reverts the Script/Agent tab to Pydantic AI's native `MCPServerStreamableHTTP`. The `pydanticai()` adapter returns `PydanticAIToolDefinition` schema objects with no execution path — `Agent(tools=...)` requires callable `Tool` instances.
- **deepagents.mdx**: Reverts to `langchain-mcp-adapters.MultiServerMCPClient`, which produces actual `DynamicStructuredTool` instances compatible with `create_deep_agent`.

## Test plan

- [ ] Verify `langchain.mdx` manual loop imports (`execute_langchain_tool_call`, `HumanMessage`, `ToolMessage`) are correct
- [ ] Verify `pydantic-ai.mdx` Script tab uses `MCPServerStreamableHTTP` with `CIVIC_TOKEN`
- [ ] Verify `deepagents.mdx` uses `MultiServerMCPClient` with streamable HTTP transport
- [ ] Check all pages render correctly in the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)