### PR TITLE
Add bryn-poc pixel script to docs site

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -110,6 +110,14 @@ const config: Config = {
     './src/clientModules/gtm.ts',
   ],
 
+  scripts: [
+    {
+      src: 'https://bryn-poc.civic.com/pixel.js',
+      'data-tenant': 'civic',
+      async: true,
+    },
+  ],
+
   headTags: [
     {
       tagName: 'link',


### PR DESCRIPTION
## Summary
Adds the `bryn-poc.civic.com/pixel.js` tracking pixel to the docs site.

The script is injected into the `<head>` of **every** page via Docusaurus's top-level `scripts` config field, rendering as:

```html
<script src="https://bryn-poc.civic.com/pixel.js" data-tenant="civic" async></script>
```

## Why this approach
Docusaurus generates all pages, so external scripts go through config rather than raw HTML. The `scripts` field is purpose-built for `<script src>` tags and passes custom attributes (`data-tenant`) and boolean attributes (`async`) through verbatim.

## Verification
- `pnpm build` succeeds
- Confirmed the rendered tag in `build/index.html` matches the requested markup exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)