### PR TITLE
docs(bryn): add website personalization recipes page

### DIFF
--- a/docs/bryn/frontend-recipes.mdx
+++ b/docs/bryn/frontend-recipes.mdx
@@ -1,0 +1,176 @@
+---
+title: Website Personalization Recipes
+description: 'Copy-paste snippets to personalize your site with the Bryn pixel'
+---
+
+Copy-paste snippets for the team that manages a Bryn customer's website (often
+non-engineers). Each snippet is paste-ready: drop it in a `<script>` alongside the Bryn
+pixel snippet, or hand it to a developer.
+
+## How it works (the one thing to know)
+
+When Bryn recognizes a visitor, it announces it on the page — your code listens and
+reacts. Bryn never changes your page for you; you decide what to show.
+
+It announces in three ways (use whichever suits you):
+1. A JavaScript event, `bryn:personalize` — **most flexible** (Recipes 1–4).
+2. A global, `window.bryn` — read the latest at any time (Recipe 6).
+3. `data-bryn-*` attributes — **no JavaScript needed** (Recipe 5).
+
+### What you get back
+
+```js
+{
+  status: "resolved",          // "pending" while Bryn is still working; "resolved" when it knows the visitor
+  entity: {                     // the COMPANY (always present once resolved)
+    companyName: "Acme Corp",
+    domain: "acme.com",
+    industry: "...", country: "...", employees: "...", stage: "...",
+    signals: ["pricing-page-viewed", "high-intent"]   // what the company has done
+  },
+  individual: {                 // the PERSON — or null if Bryn only knows the company
+    firstName: "Alex",
+    title: "VP Marketing",
+    email: "...", lastName: "...", seniority: "...", linkedin: "...",
+    signals: ["demo-requested"]                        // what this person has done
+  }
+}
+```
+
+Two simple rules:
+- **`individual` is `null`** when Bryn knows the company but not the specific person. Always check for it.
+- **The score is never sent to your page** — you react to who they are (`entity` / `individual`) and what they've done (`signals`), not to a number.
+
+## Recipe 1 — Greet a returning person by name
+
+Best when you want a personal touch and only when Bryn actually knows the person.
+
+```html
+<script>
+  window.addEventListener("bryn:personalize", (event) => {
+    const { status, individual } = event.detail;
+    if (status !== "resolved" || !individual) return;   // not resolved, or company-only
+
+    // Example: show a banner element you already have on the page
+    const banner = document.querySelector("#welcome-banner");
+    banner.textContent = `Welcome back, ${individual.firstName}!`;
+    banner.style.display = "block";
+  });
+</script>
+```
+
+## Recipe 2 — Account-level greeting (company, no name)
+
+Fires far more often than Recipe 1 (Bryn resolves the company for most visits). Keep the
+tone light — you inferred the company, the visitor didn't tell you who they are.
+
+```html
+<script>
+  window.addEventListener("bryn:personalize", (event) => {
+    const { status, entity, individual } = event.detail;
+    if (status !== "resolved" || individual) return;    // handle the company-ONLY case here
+
+    const banner = document.querySelector("#welcome-banner");
+    banner.textContent = `Exploring Bryn for the team at ${entity.companyName}? We can help.`;
+    banner.style.display = "block";
+  });
+</script>
+```
+
+## Recipe 3 — Person if known, otherwise company (the common combined pattern)
+
+```html
+<script>
+  window.addEventListener("bryn:personalize", (event) => {
+    const { status, entity, individual } = event.detail;
+    if (status !== "resolved") return;
+
+    const banner = document.querySelector("#welcome-banner");
+    banner.textContent = individual
+      ? `Welcome back, ${individual.firstName}!`                      // we know the person
+      : `Someone from ${entity.companyName} is here — say hello.`;    // company only
+    banner.style.display = "block";
+  });
+</script>
+```
+
+## Recipe 4 — Only react when there's buying intent
+
+Being recognized isn't the same as being interested. Gate on a **signal** so you only act
+on visitors doing something meaningful. Your active signals are the ones you configured in
+Bryn (e.g. `pricing-page-viewed`, `demo-requested`) — use your own names here.
+
+```html
+<script>
+  window.addEventListener("bryn:personalize", (event) => {
+    const { status, entity } = event.detail;
+    if (status !== "resolved") return;
+
+    // Show a "Talk to sales" nudge only if the company has shown pricing intent
+    if (entity.signals.includes("pricing-page-viewed")) {
+      document.querySelector("#talk-to-sales").style.display = "block";
+    }
+  });
+</script>
+```
+
+## Recipe 5 — No JavaScript at all: the `data-bryn-*` attributes
+
+The most powerful option for non-engineers — personalize purely in your HTML, no script.
+Every attribute takes a **bryn path** into the payload (`entity.companyName`,
+`individual.firstName`, `signals`, `status`, …; a bare `companyName` checks both sections,
+person first).
+
+**Fill in text** — `data-bryn-field` sets an element's text; your fallback stays if the
+field isn't known for this visitor:
+
+```html
+<h1>Welcome back, <span data-bryn-field="entity.companyName">your team</span>!</h1>
+<p>Nice to see you, <span data-bryn-field="individual.firstName"></span>.</p>
+```
+
+**Show / hide** — `data-bryn-show` / `data-bryn-hide` reveal or hide an element on a
+condition (a path that's present/true, or `path=value`). Author the default state in
+your markup; Bryn toggles the standard `hidden` attribute once it resolves, so the page is
+never broken while cold:
+
+```html
+<!-- greet the person only when Bryn knows who they are -->
+<div hidden data-bryn-show="individual.firstName">
+  Welcome back, <span data-bryn-field="individual.firstName"></span>!
+</div>
+
+<!-- show a pricing CTA only when the company viewed pricing (use your own signal names) -->
+<div hidden data-bryn-show="signals.pricing-page-viewed">Talk to sales about pricing →</div>
+
+<!-- a loading line that disappears once resolved -->
+<div data-bryn-hide="status=resolved">Personalizing…</div>
+```
+
+## Recipe 6 — Read the latest at any time (`window.bryn`)
+
+If your code runs after Bryn has already resolved (e.g. on a button click), read the
+global instead of waiting for the event:
+
+```html
+<script>
+  document.querySelector("#book-demo").addEventListener("click", () => {
+    const visitor = window.bryn;   // latest payload, or undefined if not resolved yet
+    if (visitor?.status === "resolved") {
+      // e.g. prefill a form or tag your analytics
+      analytics.track("demo_click", { company: visitor.entity.companyName });
+    }
+  });
+</script>
+```
+
+## Good habits
+
+- **Always keep a sensible default.** A cold or unknown visitor gets `status: "pending"`
+  and no data — your page must look right before Bryn does anything. Never hide content
+  behind personalization.
+- **Check `individual` for `null`.** Company-only is the common case; don't assume a name.
+- **Personalize, don't startle.** For company-only (inferred from network, not self-identified),
+  keep it helpful and low-key rather than "we know exactly who you are."
+- **Nothing sensitive reaches the page** — no scores, no internal IDs. Just safe display
+  attributes and the signal labels you configured.

--- a/sidebars/bryn.ts
+++ b/sidebars/bryn.ts
@@ -11,6 +11,7 @@ const TOP_GROUP = { collapsible: false as const, collapsed: false as const };
 const sidebar: SidebarItemConfig[] = [
   { type: 'doc', id: 'bryn/index', label: 'Overview' },
   { type: 'doc', id: 'bryn/mcp', label: 'MCP Server' },
+  { type: 'doc', id: 'bryn/frontend-recipes', label: 'Personalization Recipes' },
   {
     type: 'category',
     label: 'Control Plane API',


### PR DESCRIPTION
## What

Adds a new **Website Personalization Recipes** page under the Bryn docs tab
(`/bryn/frontend-recipes`) plus a sidebar entry ("Personalization Recipes").

The page is a copy-paste guide for the team that manages a Bryn customer's
website (often non-engineers) — how to react when the Bryn pixel recognizes a
visitor. It covers the three personalization surfaces:

1. The `bryn:personalize` JavaScript event (Recipes 1–4)
2. The `window.bryn` global (Recipe 6)
3. The declarative `data-bryn-*` attributes — no JavaScript (Recipe 5)

...plus the `{ status, entity, individual }` return-leg payload contract and a
"good habits" section.

## Source & context

Adapted from the internal bryn recipe doc
(`etc/docs/recipes/on-visit-personalization.md`) and kept consistent with the
declarative `data-bryn-*` vocabulary and payload shape shipped in
civicteam/bryn#824. Internal repo references (spec paths, control-plane-ui
component paths, `etc/docs/pixel.md`) are stripped for public docs.

## Changes

- `docs/bryn/frontend-recipes.mdx` — new page
- `sidebars/bryn.ts` — sidebar entry after "MCP Server"

## Verification

- `pnpm build` succeeds — MDX compiles and the new sidebar `id` resolves, no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)