### PR TITLE
docs(bryn): add request signing guide [BRYN-1016]

### DIFF
--- a/docs/bryn/frontend-recipes.mdx
+++ b/docs/bryn/frontend-recipes.mdx
@@ -23,12 +23,14 @@ It announces in three ways (use whichever suits you):
 {
   status: "resolved",          // "pending" while Bryn is still working; "resolved" when it knows the visitor
   entity: {                     // the COMPANY (always present once resolved)
+    entityId: "39dbb553-...",   // stable id for this company — echo it back on server-side events
     companyName: "Acme Corp",
     domain: "acme.com",
     industry: "...", country: "...", employees: "...", stage: "...",
     signals: ["pricing-page-viewed", "high-intent"]   // what the company has done
   },
   individual: {                 // the PERSON, or null if Bryn only knows the company
+    individualId: "5f2b8c1e-...", // stable id for this person — echo it back on server-side events
     firstName: "Alex",
     title: "VP Marketing",
     email: "...", lastName: "...", seniority: "...", linkedin: "...",
@@ -37,9 +39,11 @@ It announces in three ways (use whichever suits you):
 }
 ```
 
-Two rules:
+Three rules:
 - **`individual` is `null`** when Bryn knows the company but not the specific person. Always check for it.
 - **The score is never sent to your page.** You react to who they are (`entity` / `individual`) and what they've done (`signals`), not to a number.
+- **`entityId` and `individualId` are stable identity keys.** Capture them and send them back on your
+  server-side events so both sources stitch to the same records — see [Signing requests](/bryn/signing).
 
 ## Recipe 1: Greet a returning person by name
 

--- a/docs/bryn/signing.mdx
+++ b/docs/bryn/signing.mdx
@@ -96,6 +96,31 @@ await fetch(`https://bryn.civic.com/ingest/custom/${tenantId}`, {
   </Tab>
 </Tabs>
 
+## Linking to a known company or person
+
+By default Bryn resolves each event to a company — and to a person when you send an
+`email` — from the fields in the body. If you already know which Bryn record an event
+belongs to, name it directly with a `bryn` block in `properties`:
+
+```json
+{
+  "eventType": "demo.requested",
+  "properties": {
+    "bryn": { "entityId": "39dbb553-5940-41fd-ab43-479c9bceac37" },
+    "email": "alex@acme.com"
+  }
+}
+```
+
+- `entityId` attaches the event to that **company**.
+- `individualId` attaches it to a specific **person**.
+
+You get these ids from the **Bryn pixel**: when it recognizes a visitor, it exposes a
+stable `entity.entityId` and `individual.individualId` in its personalization payload.
+Capture them on your site and echo them back on your server-side events so both sources
+stitch to the same records. See [Personalization Recipes](/bryn/frontend-recipes) for
+how the pixel surfaces visitor data.
+
 ## What Bryn checks
 
 A request is accepted only when all of these hold:

--- a/docs/bryn/signing.mdx
+++ b/docs/bryn/signing.mdx
@@ -1,0 +1,114 @@
+---
+title: Signing requests
+description: 'Sign your requests to the Bryn custom ingest webhook with an HMAC signature'
+---
+
+When you send events to the Bryn custom ingest webhook, you sign each request with a
+short HMAC signature so Bryn can confirm the request really came from you. This page
+shows you how.
+
+## Get your signing secret
+
+Your signing secret lives in the Control plane, under **Integrations → Ingest → Signing**.
+Reveal it there, copy it, and store it somewhere your server can read it (an environment
+variable or a secrets manager) — treat it like a password.
+
+<Note>
+The signing secret is only ever used on your server. Never put it in a browser, a mobile
+app, or anything a visitor can view. If it's ever exposed, regenerate it from the same
+Signing page — the old value stops working once the changeover completes.
+</Note>
+
+## The signature header
+
+Every signed request carries an `X-Bryn-Signature` header:
+
+```
+X-Bryn-Signature: t=<unix-seconds>,v1=<hex-digest>
+```
+
+- `t` is the current time in whole seconds since the Unix epoch.
+- `v1` is a hex-encoded **HMAC-SHA256** digest of the string `<t>.<body>` — the timestamp,
+  a literal dot, then the exact request body — keyed with your signing secret.
+
+## Sign a request
+
+<Steps>
+<Step title="Build the request body">
+Serialize your event once, and keep that exact string. You sign and send the **same bytes** —
+re-serializing the JSON afterwards can reorder keys or change whitespace and break the signature.
+</Step>
+<Step title="Compute the signature">
+Take the current Unix time as `t`, join it to the body as `<t>.<body>`, and compute the
+HMAC-SHA256 digest of that string with your signing secret.
+</Step>
+<Step title="Send the request">
+POST the body to your tenant's ingest URL with the `X-Bryn-Signature` header. Send within
+**five minutes** of the timestamp you signed — Bryn rejects signatures outside that window.
+</Step>
+</Steps>
+
+<Tabs>
+  <Tab title="cURL">
+
+```bash
+SECRET="whsec_your_signing_secret"   # Control plane → Integrations → Ingest → Signing
+TENANT="your-tenant-id"
+BODY='{"eventType":"demo.requested","properties":{"email":"alex@acme.com"}}'
+
+TS=$(date +%s)
+SIG=$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | sed 's/^.* //')
+
+curl -X POST "https://bryn.civic.com/ingest/custom/$TENANT" \
+  -H "Content-Type: application/json" \
+  -H "X-Bryn-Signature: t=$TS,v1=$SIG" \
+  --data-raw "$BODY"
+```
+
+  </Tab>
+  <Tab title="JavaScript">
+
+```js
+import { createHmac } from "node:crypto";
+
+const secret = process.env.BRYN_SIGNING_SECRET; // Control plane → Integrations → Ingest → Signing
+const tenantId = "your-tenant-id";
+
+// Serialize once and reuse the same string for both signing and sending.
+const body = JSON.stringify({
+  eventType: "demo.requested",
+  properties: { email: "alex@acme.com" },
+});
+
+const t = Math.floor(Date.now() / 1000);
+const v1 = createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
+
+await fetch(`https://bryn.civic.com/ingest/custom/${tenantId}`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "X-Bryn-Signature": `t=${t},v1=${v1}`,
+  },
+  body,
+});
+```
+
+  </Tab>
+</Tabs>
+
+## What Bryn checks
+
+A request is accepted only when all of these hold:
+
+- The `X-Bryn-Signature` header is present and well-formed.
+- The timestamp is within five minutes of Bryn's clock.
+- The `v1` digest matches Bryn's own HMAC of `<t>.<body>` using your signing secret.
+
+If any check fails, Bryn responds with `401` and the event is not recorded. A successful
+request returns `204`.
+
+## Rotating your secret
+
+Regenerate the signing secret from the same **Signing** page whenever you need to. Update
+your server to sign with the new value; the previous secret keeps working briefly during
+the changeover so in-flight requests aren't dropped.

--- a/sidebars/bryn.ts
+++ b/sidebars/bryn.ts
@@ -12,6 +12,7 @@ const sidebar: SidebarItemConfig[] = [
   { type: 'doc', id: 'bryn/index', label: 'Overview' },
   { type: 'doc', id: 'bryn/mcp', label: 'MCP Server' },
   { type: 'doc', id: 'bryn/frontend-recipes', label: 'Personalization Recipes' },
+  { type: 'doc', id: 'bryn/signing', label: 'Signing requests' },
   {
     type: 'category',
     label: 'Control Plane API',

--- a/sidebars/bryn.ts
+++ b/sidebars/bryn.ts
@@ -12,12 +12,19 @@ const sidebar: SidebarItemConfig[] = [
   { type: 'doc', id: 'bryn/index', label: 'Overview' },
   { type: 'doc', id: 'bryn/mcp', label: 'MCP Server' },
   { type: 'doc', id: 'bryn/frontend-recipes', label: 'Personalization Recipes' },
-  { type: 'doc', id: 'bryn/signing', label: 'Signing requests' },
   {
     type: 'category',
     label: 'Control Plane API',
     ...TOP_GROUP,
     items: brynApiSidebar as SidebarItemConfig[],
+  },
+  // Collapsed by default: signing is an integration detail most readers don't need up front.
+  {
+    type: 'category',
+    label: 'Advanced',
+    collapsible: true,
+    collapsed: true,
+    items: [{ type: 'doc', id: 'bryn/signing', label: 'Signing requests' }],
   },
 ];
 


### PR DESCRIPTION
Adds a **Signing requests** page under `docs/bryn/` explaining how to sign requests to the Bryn custom ingest webhook, with tabbed **cURL** and **JavaScript** examples.

- Signature scheme: `X-Bryn-Signature: t=<unix>,v1=<hex>`, HMAC-SHA256 over `<t>.<body>`, 5-minute replay window (matches `apps/pipeline-ingest/src/ingest/signature.ts`).
- Endpoint: `https://bryn.civic.com/ingest/custom/{tenantId}` (verified against the k8s ingress — `pipeline-ingest` `ingressPaths: [/ingest]`, forwarded as-is).
- Registered in the Bryn sidebar; `pnpm build` passes.

Note: describes signing the custom webhook, which begins verifying signatures once the ingest-side HMAC wiring ships (BRYN-1014). Publishing docs first is intentional and approved.