### PR TITLE
fix(ci): update lychee include_fragments to the string enum form

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -85,8 +85,9 @@ max_redirects = 10
 # Cache results for 1 day
 cache = true
 
-# Include fragment checking (anchors)
-include_fragments = true
+# Include fragment checking (anchors). lychee 0.19+ changed this from a boolean
+# to a string enum ("full" = check all fragments, the former `true`).
+include_fragments = "full"
 
 # Fallback extensions for checking files without extensions.
 # Lychee runs against the built site (see .github/workflows/link-check-*.yml),


### PR DESCRIPTION
## Why link-check is red on every PR

`lycheeverse/lychee-action@v2.9.0` shipped 2026-07-09 and the unpinned `@v2` tag moved to it, bumping the bundled lychee to a build where **`include_fragments` is a string enum, not a boolean**. Our `lychee.toml` still had `include_fragments = true` (unchanged since April), so lychee now fails to parse the config before checking any link:

```
TOML parse error at line 89, column 21
   include_fragments = true
                       ^^^^  wanted string or table
```

This is a repo-wide breakage (hits all open PRs), unrelated to any content change.

## Fix

`include_fragments = "full"` — the string lychee's own [canonical example](https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml) ships, equivalent to the former `true` (check all fragments).

## Optional follow-up (not in this PR)

Pin `lycheeVersion` on both `link-check-*.yml` workflows so an unpinned `@v2` can't silently drift again. Left out here to keep the fix minimal.