### PR TITLE
docs: make Bryn the first and default tab [BRYN-1086]

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,6 +3,9 @@ title: Civic Documentation
 description: >-
   The agent integrator for mid-market businesses. Platform documentation for
   Bryn, Civic Hub, Civic Auth, and Civic Labs.
+# The site root (/) redirects to /bryn via src/pages/index.tsx; this welcome
+# page lives at /welcome and stays the Civic sidebar's first item.
+slug: /welcome
 sidebar_custom_props:
   icon: "octopus"
 ---

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -19,6 +19,7 @@ const hideBryn = process.env.HIDE_BRYN === "true";
 
 const config: Config = {
   title: "Civic Docs",
+  customFields: { hideBryn },
   tagline:
     "The agent integrator for mid-market businesses. Platform documentation for Civic Hub, Civic Auth, and Civic Labs.",
   favicon: "/favicon.svg",
@@ -205,6 +206,18 @@ const config: Config = {
         href: "/",
       },
       items: [
+        // Bryn leads: it is the default landing tab (src/pages/index.tsx
+        // redirects / to /bryn unless HIDE_BRYN is set).
+        ...(hideBryn
+          ? []
+          : [
+              {
+                type: "docSidebar" as const,
+                sidebarId: "bryn",
+                label: "Bryn",
+                position: "left" as const,
+              },
+            ]),
         {
           type: "docSidebar",
           sidebarId: "civic",
@@ -223,16 +236,6 @@ const config: Config = {
           label: "Labs",
           position: "left",
         },
-        ...(hideBryn
-          ? []
-          : [
-              {
-                type: "docSidebar" as const,
-                sidebarId: "bryn",
-                label: "Bryn",
-                position: "left" as const,
-              },
-            ]),
         {
           label: "Contact Us",
           href: CONTACT_URL,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Redirect } from '@docusaurus/router';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+/**
+ * Bryn is the default tab: the site root forwards to /bryn. When the Bryn tab
+ * is hidden for an environment (HIDE_BRYN=true), fall back to the Civic
+ * welcome page instead so the root never lands on a hidden product.
+ */
+export default function Home(): JSX.Element {
+  const { siteConfig } = useDocusaurusContext();
+  const hideBryn = siteConfig.customFields?.hideBryn === true;
+  return <Redirect to={hideBryn ? '/welcome' : '/bryn'} />;
+}


### PR DESCRIPTION
Follow-up to #896: Bryn becomes the front door of docs.civic.com.

## What changed

- **Navbar order**: Bryn Civic Auth Labs (Bryn was last). The tab stays conditional on `HIDE_BRYN`.
- **Default landing**: `/` now redirects to `/bryn` via a minimal `src/pages/index.tsx`. In environments with `HIDE_BRYN=true` it falls back to `/welcome` instead, so the root never lands on a hidden tab (`hideBryn` exposed through `customFields`).
- **Welcome page**: `docs/index.mdx` moves to `/welcome` (frontmatter slug only; it remains the Civic sidebar's first item, so the Civic tab now opens there).

## Verification

- `pnpm build` green, no route conflicts or broken-link warnings.
- Browser-verified: visiting `/` lands on `/bryn` with the Bryn tab first and active; `/welcome` serves the product-cards homepage; `/civic/overview` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)