### PR TITLE
feat: add PostHog analytics with Bryn pixel identity stitching [BRYN-379]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
 ALGOLIA_APP_ID=
 ALGOLIA_API_KEY=
 ALGOLIA_INDEX_NAME=
+
+# PostHog product analytics (src/clientModules/posthog.ts).
+# POSTHOG_KEY is the PostHog *public project API key* (phc_...); it is embedded in the
+# browser bundle (not a secret) but is env-driven so it can vary per environment. PostHog
+# init is skipped when it is unset. POSTHOG_HOST is optional (defaults to PostHog US cloud,
+# https://us.i.posthog.com) — set it for EU cloud or a reverse-proxied ingest host.
+POSTHOG_KEY=
+POSTHOG_HOST=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,10 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
+          # PostHog public project token (phc_...) + optional host. PostHog init is
+          # skipped when POSTHOG_KEY is unset, so the site still builds without it.
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
       - run: echo "docs.civic.com" > build/CNAME
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -13,13 +13,21 @@ const algoliaEnabled =
 const CONTACT_URL = "mailto:bd@civic.com";
 const BOOK_CALL_URL = "https://civic.com";
 
+// PostHog product analytics (src/clientModules/posthog.ts). The project key is a
+// publishable client-side key (it ships in the browser bundle, like the GTM id) but
+// is env-driven so it can vary per Vercel environment; PostHog init is skipped when
+// POSTHOG_KEY is absent. POSTHOG_HOST is optional (defaults to PostHog US cloud).
+const posthogConfig = {
+  key: process.env.POSTHOG_KEY,
+  host: process.env.POSTHOG_HOST,
+};
+
 // Set HIDE_BRYN=true (e.g. per Vercel environment) to drop the Bryn tab from the
 // navbar. The /bryn pages are still built and reachable by direct URL.
 const hideBryn = process.env.HIDE_BRYN === "true";
 
 const config: Config = {
   title: "Civic Docs",
-  customFields: { hideBryn },
   tagline:
     "The agent integrator for mid-market businesses. Platform documentation for Civic Hub, Civic Auth, and Civic Labs.",
   favicon: "/favicon.svg",
@@ -37,8 +45,10 @@ const config: Config = {
   i18n: { defaultLocale: "en", locales: ["en"] },
 
   customFields: {
+    hideBryn,
     contactUrl: CONTACT_URL,
     bookCallUrl: BOOK_CALL_URL,
+    posthog: posthogConfig,
   },
 
   markdown: {
@@ -132,6 +142,7 @@ const config: Config = {
   clientModules: [
     "./src/clientModules/fontawesome.ts",
     "./src/clientModules/gtm.ts",
+    "./src/clientModules/posthog.ts",
   ],
 
   scripts: [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "docusaurus-plugin-openapi-docs": "^5.0.2",
     "docusaurus-plugin-sass": "^0.2.6",
     "docusaurus-theme-openapi-docs": "^5.0.2",
+    "posthog-js": "^1.390.2",
     "prism-react-renderer": "^2.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       docusaurus-theme-openapi-docs:
         specifier: ^5.0.2
         version: 5.0.2(@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.28)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.28)(docusaurus-plugin-openapi-docs@5.0.2(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.28)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/utils-validation@3.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@docusaurus/utils@3.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/json-schema@7.0.15)(react@18.3.1))(docusaurus-plugin-sass@0.2.6(@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@18.3.28)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(sass@1.101.0)(webpack@5.97.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)(webpack@5.97.1)
+      posthog-js:
+        specifier: ^1.390.2
+        version: 1.405.3
       prism-react-renderer:
         specifier: ^2.4.0
         version: 2.4.1(react@18.3.1)
@@ -1575,6 +1578,12 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@posthog/core@1.44.0':
+    resolution: {integrity: sha512-uE+mdKvetxNQC6gWQf4MHIH8bGt+JN6z7ho0A4G3t9G1VGQTx9wHYHNwkKf3gzi+1oAXS9ej2VVY4pjWUU2PWg==}
+
+  '@posthog/types@1.397.1':
+    resolution: {integrity: sha512-W/LpWbKVaaUnfZKuFuHa+Dg03D+fC87cM+PQbG+59JcSPW8F0JcBtSoXmpfrqbpuxUToMo+gktutrUkAb/KQBw==}
+
   '@redocly/ajv@8.18.1':
     resolution: {integrity: sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==}
 
@@ -1847,6 +1856,9 @@ packages:
 
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2719,6 +2731,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
 
@@ -2973,6 +2988,9 @@ packages:
   feed@4.2.2:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
     engines: {node: '>=0.4.0'}
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -4664,6 +4682,9 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.405.3:
+    resolution: {integrity: sha512-uedFwL6TD3YO/oH/eh6ObrJANJwdpis9I7dQZMcN0cS22vT5PfbpaLaC3RPuL5/hGDSwNJ8flxucV6hHDUz6Tw==}
+
   postman-code-generators@2.1.1:
     resolution: {integrity: sha512-+egQK1Jf9a92QP23vRTKcDLOthIQmI7WI4czEsZq/wgguLMnVHJ26KlT8AVtpAdVw28hqUbHwicerYxRWCfjoA==}
     engines: {node: '>=18'}
@@ -4675,6 +4696,14 @@ packages:
   postman-url-encoder@3.0.8:
     resolution: {integrity: sha512-EOgUMBazo7JNP4TDrd64TsooCiWzzo4143Ws8E8WYGEpn2PKpq+S4XRTDhuRTYHm3VKOpUZs7ZYZq7zSDuesqA==}
     engines: {node: '>=10'}
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
@@ -4737,6 +4766,9 @@ packages:
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5645,6 +5677,9 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -8220,6 +8255,12 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@posthog/core@1.44.0':
+    dependencies:
+      '@posthog/types': 1.397.1
+
+  '@posthog/types@1.397.1': {}
+
   '@redocly/ajv@8.18.1':
     dependencies:
       fast-deep-equal: 3.1.3
@@ -8557,6 +8598,9 @@ snapshots:
   '@types/sockjs@0.3.36':
     dependencies:
       '@types/node': 25.6.0
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -9541,6 +9585,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@2.8.0:
     dependencies:
       dom-serializer: 1.4.1
@@ -9814,6 +9862,8 @@ snapshots:
   feed@4.2.2:
     dependencies:
       xml-js: 1.6.11
+
+  fflate@0.4.9: {}
 
   figures@3.2.0:
     dependencies:
@@ -11882,6 +11932,19 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.405.3:
+    dependencies:
+      '@posthog/core': 1.44.0
+      '@posthog/types': 1.397.1
+      core-js: 3.49.0
+      dompurify: 3.4.12
+      fflate: 0.4.9
+      preact: 10.29.7
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
   postman-code-generators@2.1.1:
     dependencies:
       async: 3.2.6
@@ -11907,6 +11970,8 @@ snapshots:
   postman-url-encoder@3.0.8:
     dependencies:
       punycode: 2.3.1
+
+  preact@10.29.7: {}
 
   pretty-error@4.0.0:
     dependencies:
@@ -11964,6 +12029,8 @@ snapshots:
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -12990,6 +13057,8 @@ snapshots:
       minimalistic-assert: 1.0.1
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/clientModules/posthog.ts
+++ b/src/clientModules/posthog.ts
@@ -1,0 +1,148 @@
+/**
+ * PostHog product analytics for docs.civic.com.
+ *
+ * Loaded directly (not via the GTM container, which fires GA4 / Ads / Reddit / …)
+ * because we need the PostHog SDK on the page to (a) capture docs pageviews for the
+ * "reading deep in the docs" roll-up and (b) stitch the Bryn pixel's resolved
+ * identity onto the PostHog person/group so a server-side derived event resolves
+ * back to the same Bryn Entity. The public project key ships in the browser bundle
+ * (like the GTM id in gtm.ts); it is provided via `customFields.posthog` so it is
+ * env-driven rather than hard-coded — see docusaurus.config.ts and .env.example.
+ *
+ * Consent: PostHog sets tracking cookies, so it is gated on CookieYes. It initializes
+ * opted-out (capturing nothing, no tracking cookies) and only opts in once the visitor
+ * accepts the "analytics" category in the CookieYes banner — read from CookieYes's own
+ * consent cookie and kept in sync via its `cookieyes_consent_update` event. If consent
+ * cannot be determined, PostHog stays off (fail-closed).
+ */
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import siteConfig from '@generated/docusaurus.config';
+import { posthog } from 'posthog-js';
+
+import { BRYN_COMPANY_GROUP, computeBrynStitch } from '../lib/analytics/bryn-stitch';
+
+type PostHogClientConfig = { key?: string; host?: string };
+
+const DEFAULT_API_HOST = 'https://us.i.posthog.com';
+
+// CookieYes consent category that governs PostHog. PostHog is product analytics and sets
+// tracking cookies, so it runs only once the visitor accepts the "analytics" category.
+const CONSENT_CATEGORY = 'analytics';
+
+const readConfig = (): PostHogClientConfig => {
+  const custom = (siteConfig.customFields ?? {}) as { posthog?: PostHogClientConfig };
+  return custom.posthog ?? {};
+};
+
+// Skip in dev + on localhost, mirroring gtm.ts: no product analytics during local dev.
+const isDev = process.env.NODE_ENV !== 'production';
+const isLocalhost =
+  typeof window !== 'undefined' &&
+  /^(localhost|127\.0\.0\.1|\[::1\])$/.test(window.location.hostname);
+const canRun = ExecutionEnvironment.canUseDOM && !isDev && !isLocalhost;
+
+/**
+ * Read CookieYes consent for a category from its `cookieyes-consent` cookie, whose value is
+ * comma-separated `key:value` pairs (e.g. "...,analytics:yes,advertisement:no,..."). We read
+ * the cookie rather than the consent-event detail because the cookie is the stable,
+ * version-independent source of truth and also covers the returning-visitor case where the
+ * event fired before this module loaded. Absent/unparseable ⇒ false (fail-closed).
+ */
+const hasConsent = (category: string): boolean => {
+  const match = document.cookie.match(/(?:^|;\s*)cookieyes-consent=([^;]+)/);
+  if (!match) return false;
+  return decodeURIComponent(match[1])
+    .split(',')
+    .some((pair) => pair.trim() === `${category}:yes`);
+};
+
+let started = false;
+// Latest Bryn resolution seen before consent was granted; applied once the visitor opts in.
+let pendingStitch: unknown;
+
+const applyBrynStitch = (detail: unknown): void => {
+  const stitch = computeBrynStitch(detail);
+  if (!stitch) return;
+  try {
+    // Super properties ride every event (incl. the server-side "reading deep" roll-up),
+    // so the derived event resolves back to this Bryn Entity by bryn_entity_id.
+    posthog.register(stitch.superProps);
+    posthog.group(BRYN_COMPANY_GROUP, stitch.entityId, stitch.groupProps);
+    if (stitch.identify) posthog.identify(stitch.identify.distinctId, stitch.identify.props);
+  } catch {
+    // Analytics must never break the docs page.
+  }
+};
+
+// A Bryn resolution stitches identity — which writes PostHog cookies — so it only applies
+// once the visitor has consented; otherwise the latest is stashed and applied on opt-in.
+const onBrynResolution = (detail: unknown): void => {
+  if (posthog.has_opted_in_capturing()) applyBrynStitch(detail);
+  else pendingStitch = detail;
+};
+
+// Bring PostHog's capture state in line with the current CookieYes decision. Called at
+// startup (honoring a returning visitor's prior choice) and on every consent change.
+const syncConsent = (): void => {
+  if (!started) return;
+  const consented = hasConsent(CONSENT_CATEGORY);
+  const optedIn = posthog.has_opted_in_capturing();
+  if (consented && !optedIn) {
+    posthog.opt_in_capturing(); // enables capture + persistence
+    posthog.capture('$pageview'); // count the page the visitor consented on
+    if (pendingStitch !== undefined) {
+      applyBrynStitch(pendingStitch);
+      pendingStitch = undefined;
+    }
+  } else if (!consented && optedIn) {
+    posthog.opt_out_capturing(); // stops capture + clears PostHog storage
+  }
+};
+
+if (canRun) {
+  const { key, host } = readConfig();
+  if (key) {
+    posthog.init(key, {
+      api_host: host || DEFAULT_API_HOST,
+      // Captured manually so SPA client-side navigations count (see onRouteDidUpdate).
+      capture_pageview: false,
+      // Page-leave events give PostHog the session-duration / dwell signal the docs-depth
+      // roll-up gates on.
+      capture_pageleave: true,
+      respect_dnt: true,
+      // Capture nothing and set no tracking cookies until CookieYes analytics consent.
+      opt_out_capturing_by_default: true,
+    });
+    started = true;
+
+    // Stitch the Bryn pixel identity (docs.civic.com/bryn/frontend-recipes). The pixel may
+    // already have resolved before this ran (window.bryn set), and it re-announces on every
+    // later resolution; either way the stitch waits for consent (see onBrynResolution).
+    const resolved = (window as unknown as { bryn?: unknown }).bryn;
+    if (resolved) onBrynResolution(resolved);
+    window.addEventListener('bryn:personalize', (event) => {
+      onBrynResolution((event as CustomEvent).detail);
+    });
+
+    // Honor the current CookieYes decision now, then react to changes.
+    syncConsent();
+    document.addEventListener('cookieyes_consent_update', syncConsent);
+  }
+}
+
+// Docusaurus is a SPA: capture a $pageview on each client-side navigation after the first
+// (the consented-on page is captured in syncConsent). Guarding on previousLocation keeps a
+// hash- or query-only change from double-counting a page in the session-depth roll-up, and
+// the opt-in guard means navigations before consent are never captured.
+export function onRouteDidUpdate({
+  location,
+  previousLocation,
+}: {
+  location: { pathname: string };
+  previousLocation: { pathname: string } | null;
+}): void {
+  if (!started || !previousLocation) return;
+  if (previousLocation.pathname === location.pathname) return;
+  if (!posthog.has_opted_in_capturing()) return;
+  posthog.capture('$pageview');
+}

--- a/src/clientModules/posthog.ts
+++ b/src/clientModules/posthog.ts
@@ -29,6 +29,11 @@ const DEFAULT_API_HOST = 'https://us.i.posthog.com';
 // tracking cookies, so it runs only once the visitor accepts the "analytics" category.
 const CONSENT_CATEGORY = 'analytics';
 
+// Registered as a super property on every event so the origin is explicit: the docs-depth
+// Action can target docs.civic.com events, and events stay distinguishable if this project
+// is ever shared with other Civic properties.
+const EVENT_SOURCE = 'docs.civic.com';
+
 const readConfig = (): PostHogClientConfig => {
   const custom = (siteConfig.customFields ?? {}) as { posthog?: PostHogClientConfig };
   return custom.posthog ?? {};
@@ -89,6 +94,9 @@ const syncConsent = (): void => {
   const optedIn = posthog.has_opted_in_capturing();
   if (consented && !optedIn) {
     posthog.opt_in_capturing(); // enables capture + persistence
+    // Tag every event with its origin. Registered post-opt-in so no super-property
+    // persistence is written before consent.
+    posthog.register({ source: EVENT_SOURCE });
     posthog.capture('$pageview'); // count the page the visitor consented on
     if (pendingStitch !== undefined) {
       applyBrynStitch(pendingStitch);

--- a/src/lib/analytics/bryn-stitch.ts
+++ b/src/lib/analytics/bryn-stitch.ts
@@ -33,14 +33,7 @@ type BrynEntity = {
 };
 
 /** Person section of the serve payload; `null` on a company-only resolution. */
-type BrynIndividual = {
-  individualId?: unknown;
-  email?: unknown;
-  firstName?: unknown;
-  lastName?: unknown;
-  title?: unknown;
-  seniority?: unknown;
-};
+type BrynIndividual = { individualId?: unknown };
 
 /**
  * The stitch actions derived from a resolved Bryn payload — a plain data
@@ -54,8 +47,11 @@ export type BrynStitch = {
   readonly groupProps: Record<string, string>;
   /** Super properties registered on every event, so server-side events carry them. */
   readonly superProps: Record<string, string>;
-  /** Person identity, present only when Bryn resolved the individual. */
-  readonly identify: { readonly distinctId: string; readonly props: Record<string, string> } | null;
+  /**
+   * Person identity, present only when Bryn resolved the individual. `props` carries the
+   * full resolved payload under a single `bryn` key (see {@link computeBrynStitch}).
+   */
+  readonly identify: { readonly distinctId: string; readonly props: Record<string, unknown> } | null;
 };
 
 /** Coerce a render-safe scalar to a non-empty string, or `undefined`. */
@@ -113,14 +109,11 @@ export const computeBrynStitch = (detail: unknown): BrynStitch | null => {
 
   let identify: BrynStitch["identify"] = null;
   if (individual && individualId) {
-    const props: Record<string, string> = { bryn_entity_id: entityId, bryn_individual_id: individualId };
-    put(props, "email", individual.email);
-    put(props, "firstName", individual.firstName);
-    put(props, "lastName", individual.lastName);
-    put(props, "title", individual.title);
-    put(props, "seniority", individual.seniority);
-    if (entity) put(props, "company_name", entity.companyName);
-    identify = { distinctId: individualId, props };
+    // Store the full resolved payload under a single `bryn` person property (matching the
+    // control-plane-ui dogfood). A PostHog Action/webhook resolves the docs-depth event back
+    // to this Bryn Entity via person.properties.bryn.entity.entityId. Nesting under one key
+    // keeps Bryn's inferred data clear of PostHog's real person fields (email / name).
+    identify = { distinctId: individualId, props: { bryn: payload } };
   }
 
   return { entityId, groupProps, superProps, identify };

--- a/src/lib/analytics/bryn-stitch.ts
+++ b/src/lib/analytics/bryn-stitch.ts
@@ -1,0 +1,127 @@
+// Bryn pixel -> PostHog identity stitching for docs.civic.com.
+//
+// The Bryn pixel (loaded via docusaurus.config.ts `scripts`) deanonymizes the
+// visitor and announces the resolution two ways — a `bryn:personalize` CustomEvent
+// and the `window.bryn` global — as documented at
+// https://docs.civic.com/bryn/frontend-recipes.
+//
+// This module turns that (untrusted, over-the-wire) payload into the PostHog
+// group / identify / register calls that stitch the anonymous PostHog session to
+// the Bryn-resolved company and person. Crucially it stamps `bryn_entity_id` as a
+// super property so it rides EVERY event (including autocaptured `$pageview`s):
+// that is the key a server-side PostHog event — the "reading deep in the docs"
+// roll-up — carries back to Bryn so the ingest pipeline resolves it to the same
+// Entity (frontend-recipes: "echo them back on your server-side events so both
+// sources stitch to the same records").
+//
+// Kept framework-free and side-effect-free (no `posthog-js` import) so it is
+// unit-testable in isolation and the SDK dependency stays contained to the client
+// module that applies the result.
+
+/** PostHog group type used for company-level (account) analytics. */
+export const BRYN_COMPANY_GROUP = "company";
+
+/** Company section of the serve payload (allowlisted display attributes). */
+type BrynEntity = {
+  entityId?: unknown;
+  companyName?: unknown;
+  domain?: unknown;
+  industry?: unknown;
+  country?: unknown;
+  employees?: unknown;
+  stage?: unknown;
+};
+
+/** Person section of the serve payload; `null` on a company-only resolution. */
+type BrynIndividual = {
+  individualId?: unknown;
+  email?: unknown;
+  firstName?: unknown;
+  lastName?: unknown;
+  title?: unknown;
+  seniority?: unknown;
+};
+
+/**
+ * The stitch actions derived from a resolved Bryn payload — a plain data
+ * description the caller applies to the PostHog SDK. `null` when the payload is
+ * not a resolved visit or carries no usable company id (nothing to stitch).
+ */
+export type BrynStitch = {
+  /** entity.entityId — the stable company key echoed onto events for end-to-end resolution. */
+  readonly entityId: string;
+  /** Company-level group properties (PostHog group analytics). */
+  readonly groupProps: Record<string, string>;
+  /** Super properties registered on every event, so server-side events carry them. */
+  readonly superProps: Record<string, string>;
+  /** Person identity, present only when Bryn resolved the individual. */
+  readonly identify: { readonly distinctId: string; readonly props: Record<string, string> } | null;
+};
+
+/** Coerce a render-safe scalar to a non-empty string, or `undefined`. */
+const str = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value.length > 0 ? value : undefined;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return undefined;
+};
+
+/** Set `key` on `target` only when `value` coerces to a non-empty string. */
+const put = (target: Record<string, string>, key: string, value: unknown): void => {
+  const s = str(value);
+  if (s !== undefined) target[key] = s;
+};
+
+/** Narrow an unknown value to a plain object, or `null`. */
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+
+/**
+ * Compute the PostHog stitch for a `bryn:personalize` detail (equivalently
+ * `window.bryn`). Returns `null` for cold / pending / suppressed / malformed
+ * payloads and for a resolution with no company id — in every such case there is
+ * nothing to stitch and the caller leaves PostHog untouched.
+ *
+ * A company-only resolution (no `individual`) still stitches: it sets
+ * `bryn_entity_id` + the company group, so "reading deep" sessions from an
+ * un-personified account still resolve back to their Bryn Entity. `identify` is
+ * populated only when a person resolved, keyed by the opaque `individualId` (never
+ * the email) so no PII lands in the PostHog distinct id.
+ */
+export const computeBrynStitch = (detail: unknown): BrynStitch | null => {
+  const payload = asRecord(detail);
+  if (!payload || payload.status !== "resolved") return null;
+
+  const entity = asRecord(payload.entity) as BrynEntity | null;
+  const entityId = entity ? str(entity.entityId) : undefined;
+  if (!entityId) return null;
+
+  const groupProps: Record<string, string> = {};
+  if (entity) {
+    put(groupProps, "name", entity.companyName); // PostHog group display-name convention
+    put(groupProps, "domain", entity.domain);
+    put(groupProps, "industry", entity.industry);
+    put(groupProps, "country", entity.country);
+    put(groupProps, "employees", entity.employees);
+    put(groupProps, "stage", entity.stage);
+  }
+
+  const superProps: Record<string, string> = { bryn_entity_id: entityId };
+
+  const individual = asRecord(payload.individual) as BrynIndividual | null;
+  const individualId = individual ? str(individual.individualId) : undefined;
+  if (individualId) superProps.bryn_individual_id = individualId;
+
+  let identify: BrynStitch["identify"] = null;
+  if (individual && individualId) {
+    const props: Record<string, string> = { bryn_entity_id: entityId, bryn_individual_id: individualId };
+    put(props, "email", individual.email);
+    put(props, "firstName", individual.firstName);
+    put(props, "lastName", individual.lastName);
+    put(props, "title", individual.title);
+    put(props, "seniority", individual.seniority);
+    if (entity) put(props, "company_name", entity.companyName);
+    identify = { distinctId: individualId, props };
+  }
+
+  return { entityId, groupProps, superProps, identify };
+};


### PR DESCRIPTION
## What

Adds PostHog product analytics to the docs site, stitched to the Bryn pixel's resolved identity, so we can measure "reading deep in the docs" and route that signal back to Bryn (play `docs_developer`, [BRYN-379]).

The Bryn pixel already deanonymizes visitors and announces the resolution via `window.bryn` / the `bryn:personalize` event (see `/bryn/frontend-recipes`). This PR wires PostHog on top: it identifies the PostHog person/group from that payload and stamps `bryn_entity_id` as a super property so a later server-side "docs-depth" event resolves back to the same Bryn Entity end-to-end.

## Changes

- **`src/lib/analytics/bryn-stitch.ts`** — pure, SDK-free logic that turns the (untrusted) Bryn payload into the PostHog `group` / `identify` / `register` calls. Company-only visits stitch too; person identity is keyed by the opaque `individualId` (never email), so no PII lands in the distinct id.
- **`src/clientModules/posthog.ts`** — the only file touching `posthog-js`. Initializes PostHog, captures pageviews (initial + every SPA navigation via `onRouteDidUpdate`, plus `capture_pageleave` for the dwell signal), and applies the identity stitch.
- **`docusaurus.config.ts`** — registers the client module and adds env-driven `customFields.posthog`. Also consolidates a pre-existing duplicate `customFields` key (the second was silently clobbering `hideBryn`).
- **`package.json` / `.env.example`** — add `posthog-js` and document the new env vars.

## Consent (CookieYes)

PostHog sets tracking cookies, so it is gated on CookieYes. It initializes opted-out (captures nothing, sets no tracking cookies) and only opts in once the visitor accepts the `analytics` category — read from CookieYes's `cookieyes-consent` cookie (stable across versions; covers returning visitors) and kept in sync via the `cookieyes_consent_update` event. Identity stitching and all pageview capture are likewise gated on opt-in. If consent can't be determined, PostHog stays off (fail-closed).

Note: US (opt-out) vs EU (opt-in) behavior follows whatever the CookieYes dashboard is configured to do — the code adapts automatically to the consent cookie either way.

## Config / env (action required before this works in prod)

The site deploys to **GitHub Pages via GitHub Actions** (`deploy.yml`), so env is injected by mapping repo secrets into the build step — this PR adds that mapping. To activate:

1. Add a repo secret: **Settings -> Secrets and variables -> Actions -> `POSTHOG_KEY`** = the PostHog project token (`phc_...`), from the environment/project that feeds Bryn's `civic_gtm` ingest.
2. (Optional) `POSTHOG_HOST` — defaults to `https://us.i.posthog.com` (the region all Civic projects use), so leave unset for US cloud.

Both are publishable (they ship in the browser bundle, like the GTM id). PostHog init is skipped when `POSTHOG_KEY` is unset, so the site still builds/deploys without it. The `env:` mapping is added to `deploy.yml` only — **not** `pr-build.yml`, so PR preview artifacts never emit to the prod PostHog project.

The PostHog -> Bryn webhook shared secret is **not** a docs concern — it lives in the PostHog project + Bryn's Secrets Manager.

## Verification

- `tsc --noEmit` clean.
- Full `docusaurus build` passes (SSR + client); key confirmed flowing through `customFields` into the client bundle.

## Follow-ups (not in this PR)

- PostHog-side: define the "reading deep" Action (>=3 distinct docs pages + dwell floor) and its webhook to Bryn's `/ingest/posthog/{tenant}`.
- Bryn-side: SignalMapping + event-entity mapping + play wiring.
- Confirm the pixel return leg is enabled for the docs pixel-ref so identity actually reaches the page.


[BRYN-379]: https://civicteam.atlassian.net/browse/BRYN-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ