### PR TITLE
Add canonical Bryn signals and plays/actions reference pages

### DIFF
--- a/docs/bryn/plays-and-actions-reference.mdx
+++ b/docs/bryn/plays-and-actions-reference.mdx
@@ -1,0 +1,92 @@
+---
+title: Plays and actions reference
+description: 'Canonical reference for Bryn Plays, actions, and connector capabilities'
+---
+
+This page is the canonical reference for Bryn Plays and the action words used
+to describe what a Play can do. A Play is a reusable workflow that fires when an
+account's signals, scores, and account facts match its trigger.
+
+## Status legend
+
+| Status | Meaning |
+| --- | --- |
+| Current | The Play or action exists in the shipped system today. |
+| Limited preview | The Play or action exists, but is available only to selected tenants. |
+| Planned | The Play or action is part of the roadmap and should not be described as shipped. |
+
+## Current action words
+
+These are the customer-facing action words for what a Play can do today.
+
+| Action | Status | What it does | Current destinations or dependencies |
+| --- | --- | --- | --- |
+| `draft` | Current | Creates a short human-readable brief, note, or follow-up from account context. | Account context and Play content. |
+| `alert` | Current | Posts a message to the team's selected destination. | Chat-capable connectors such as Slack, Teams, Discord, or webhook, when enabled. |
+| `hold` | Current | Pauses a Play so a human can approve, step in, or let the Play continue after the window. | Approval links and Play status tracking. |
+| `enroll` | Current | Adds a contact to an outbound sequence after review. | Instantly sequence connection. |
+| `review` | Limited preview | Reviews an account's recent activity and recommends a next step. | Account review and chat delivery. |
+
+## Connector capabilities
+
+Connectors provide capabilities. A capability is broader than a vendor: for example,
+`chat` can be served by Slack, Teams, Discord, or a webhook.
+
+| Capability | Status | Example connector types |
+| --- | --- | --- |
+| `chat` | Current | Slack, Teams, Discord, webhook |
+| `email` | Current | Resend, SES |
+| `sequence` | Current | Instantly |
+| `crm` | Current | HubSpot, Salesforce |
+| `ticket` | Current | Jira, Linear |
+
+A connector capability being available does not mean every shipped Play uses that
+capability yet. Plays are published one workflow at a time.
+
+## Current Plays
+
+| Play | Status | When it fires | Actions |
+| --- | --- | --- | --- |
+| Slack alert for active accounts | Current | An active scored account matches the starter trigger. | `alert` |
+| Outbound brief when intent climbs | Current | `high_intent` is active and the account has a contactable person. | `draft`, `alert`, `hold`, `enroll` |
+| Trial wobble assist for your AEs | Current | `trial_wobble` is active. | `draft`, `alert`, `hold` |
+| ICP-match alert from website visitors | Current | A website visitor resolves to an account whose fit score meets the ICP threshold. | `alert` |
+| Follow up when a demo is left unfinished | Current | `demo_abandonment` is active and the account has a contactable person. | `draft`, `alert`, `hold`, `enroll` |
+| Slack alert when an account converts to paid | Current | `account_converted` is active. | `alert` |
+| Account review with a recommended next step | Limited preview | `gtm_review` is active. | `review`, `alert` |
+
+## Planned actions
+
+| Action | Status | Planned effect |
+| --- | --- | --- |
+| `push` | Planned | Send a structured record to a configured attribution or reverse-ETL destination. |
+| `route` | Planned | Assign or escalate an account to the right owner. |
+| `append` | Planned | Add a note, flag, or field update to a system of record without overwriting existing customer data. |
+| `serve` | Planned | Return account-aware website content in the request path. |
+| `task` | Planned | Create a follow-up task for a human owner. |
+| `grant` | Planned | Grant access, credit, or an entitlement in response to account behavior. |
+| `record` | Planned | Write a normalized business event for downstream systems. |
+| `tag` | Planned | Add or remove a segment or status tag. |
+| `enrich` | Planned | Request or refresh third-party enrichment. |
+| `handoff` | Planned | Move an account from one owner or team to another with context. |
+
+## Planned Plays
+
+| Play | Status | Planned motion |
+| --- | --- | --- |
+| Attribution emit | Planned | Send a structured attribution record when an account is identified or an attribution-worthy milestone happens. |
+| Competitive evaluation route | Planned | Route an account that is actively comparing competitors to the right owner. |
+| Teammate-invite expansion | Planned | Alert or route expansion motion when product collaboration grows inside an account. |
+| Docs-depth developer alert | Planned | Alert a technical owner when an account shows deep documentation or API research. |
+| Trial usage-limit upgrade | Planned | Alert, append, or push when a trial approaches or hits a usage limit. |
+| Third-party intent surge | Planned | Alert or route when external intent rises for target topics. |
+| Multi-user domain activation | Planned | Alert or route when several people from one account become active. |
+| Champion job-change re-engage | Planned | Draft and queue outreach when a known champion moves to a new company. |
+| On-visit personalization | Planned | Serve account-aware page content from a precomputed content set. |
+
+## What to say publicly
+
+Use "actions" or "verbs" for the reusable effects a Play can take. Use vendor names
+only for examples of where an action can land. For example, say "Bryn posts an alert
+to your team's chat destination" before saying "Slack," because the action is `alert`
+and Slack is one possible connector.

--- a/docs/bryn/plays-and-actions-reference.mdx
+++ b/docs/bryn/plays-and-actions-reference.mdx
@@ -83,10 +83,3 @@ capability yet. Plays are published one workflow at a time.
 | Multi-user domain activation | Planned | Alert or route when several people from one account become active. |
 | Champion job-change re-engage | Planned | Draft and queue outreach when a known champion moves to a new company. |
 | On-visit personalization | Planned | Serve account-aware page content from a precomputed content set. |
-
-## What to say publicly
-
-Use "actions" or "verbs" for the reusable effects a Play can take. Use vendor names
-only for examples of where an action can land. For example, say "Bryn posts an alert
-to your team's chat destination" before saying "Slack," because the action is `alert`
-and Slack is one possible connector.

--- a/docs/bryn/signals-reference.mdx
+++ b/docs/bryn/signals-reference.mdx
@@ -56,12 +56,3 @@ their status moves to Current.
 | `bombora_surge` | Planned | A third-party intent provider reports topic surge. |
 | `g2_intent` | Planned | A third-party intent provider reports review or comparison intent. |
 | `job_change` | Planned | A known champion or buyer changes roles. |
-
-## What to say publicly
-
-Use "signals" for the normalized account facts Bryn derives from events. Use "events"
-for the raw things a connected source sends. Use "Plays" for the actions Bryn takes
-when signals, scores, and account facts match a trigger.
-
-When a signal is Planned, describe it as a roadmap area. Do not imply that a planned
-signal can trigger a production Play today.

--- a/docs/bryn/signals-reference.mdx
+++ b/docs/bryn/signals-reference.mdx
@@ -1,0 +1,67 @@
+---
+title: Signals reference
+description: 'Canonical reference for Bryn signal names and their shipping status'
+---
+
+This page is the canonical reference for Bryn signal names and their current
+shipping status. Signal names are shown without the `signal.` trigger prefix. For
+example, the `high_intent` signal appears in a Play trigger as `signal.high_intent`.
+
+## Status legend
+
+| Status | Meaning |
+| --- | --- |
+| Current | The signal can be mapped, raised, scored, or used by a shipped Play today. |
+| Limited preview | The signal is implemented, but the related Play is available only to selected tenants. |
+| Planned | The name is reserved for roadmap work and should not be described as available yet. |
+
+## How signals work
+
+Bryn accepts events from connected sources, maps those events into signal names, and
+keeps the resulting signals on the account or person that generated them. Signals
+then contribute to scoring and can trigger Plays.
+
+Signal names use lower snake case, such as `trial_wobble`. Custom tenant-defined
+signals can use the same shape when a team needs a signal outside the core catalogue.
+
+## Current signals
+
+| Signal | Status | What it means | Common source | Used by |
+| --- | --- | --- | --- | --- |
+| `identified_account` | Current | A previously anonymous visitor or event has been resolved to a known account or person. | Website identity resolution, product analytics, or another mapped identity event. | Attribution and account history. The outbound attribution Play is planned. |
+| `aha_event` | Current | A user reached the product's first clear value moment. | A tenant-defined product event, such as first project created or first message sent. | Scoring and tenant-specific Plays. No starter Play consumes it directly today. |
+| `high_intent` | Current | An account is showing buying or evaluation intent. | Pricing, plans, billing, docs, account settings, or equivalent tenant-defined events. | Outbound brief when intent climbs. |
+| `trial_wobble` | Current | A trial account is showing risk, friction, or falling engagement. | Product analytics, lifecycle automation, or a tenant-defined trial event. | Trial wobble assist for your AEs. |
+| `demo_abandonment` | Current | Someone started a demo or tour but left before finishing. | Demo, tour, or product-led motion events. | Follow up when a demo is left unfinished. |
+| `gtm_review` | Limited preview | An account is due for a go-to-market review and a recommended next step. | Any tenant-defined event that should send the account for review. | Account review with a recommended next step. |
+| `account_converted` | Current | A tracked account became a paying customer. | Subscription, billing, or lifecycle events mapped by the tenant. | Slack alert when an account converts to paid. |
+| `competitor_comparison` | Current | A website visitor viewed configured competitor-comparison content. | Website pixel URL rules configured by the tenant. | Scoring and future competitive Plays. The current ICP-match Play uses fit score rather than this signal. |
+
+## Planned signals
+
+These names describe planned or roadmap signal categories. They are useful for
+content planning, but they should not be presented as generally available until
+their status moves to Current.
+
+| Signal | Status | Planned meaning |
+| --- | --- | --- |
+| `pricing_repeat` | Planned | Pricing or plan pages viewed repeatedly within a recent account window. |
+| `docs_research` | Planned | Deep documentation or API research in one account session. |
+| `repeat_visit` | Planned | Multiple recent visits from the same account. |
+| `demo_no_fill` | Planned | A demo page was visited but no form or demo-start event followed. |
+| `signup_abandon` | Planned | Sign-up started but did not complete. |
+| `teammate_invite` | Planned | A product user invited teammates, especially more than once in a session. |
+| `multi_user_domain` | Planned | Multiple users from the same domain are active in a trial or workspace. |
+| `usage_limit` | Planned | An account hit or approached a product usage limit. |
+| `bombora_surge` | Planned | A third-party intent provider reports topic surge. |
+| `g2_intent` | Planned | A third-party intent provider reports review or comparison intent. |
+| `job_change` | Planned | A known champion or buyer changes roles. |
+
+## What to say publicly
+
+Use "signals" for the normalized account facts Bryn derives from events. Use "events"
+for the raw things a connected source sends. Use "Plays" for the actions Bryn takes
+when signals, scores, and account facts match a trigger.
+
+When a signal is Planned, describe it as a roadmap area. Do not imply that a planned
+signal can trigger a production Play today.

--- a/sidebars/bryn.ts
+++ b/sidebars/bryn.ts
@@ -78,6 +78,16 @@ const sidebar: SidebarItemConfig[] = [
   { type: 'doc', id: 'bryn/mcp', label: 'MCP server', customProps: icon('message') },
   {
     type: 'category',
+    label: 'Reference',
+    customProps: icon('book'),
+    ...TOP_GROUP,
+    items: [
+      { type: 'doc', id: 'bryn/signals-reference', label: 'Signals', customProps: icon('signal') },
+      { type: 'doc', id: 'bryn/plays-and-actions-reference', label: 'Plays & actions', customProps: icon('circle-play') },
+    ],
+  },
+  {
+    type: 'category',
     label: 'Advanced',
     customProps: icon('code'),
     ...TOP_GROUP,


### PR DESCRIPTION
**Summary**: Adds the canonical public reference pages for Bryn under the Bryn docs tab: a Signals reference and a Plays & actions reference. Both distinguish shipped (Current), Limited preview, and Planned status so marketing and technical content have a single source of truth for terminology.

**Type**: Feature (docs)

Two new pages:
- `docs/bryn/signals-reference.mdx` — signal names, meanings, sources, and shipping status (current + planned).
- `docs/bryn/plays-and-actions-reference.mdx` — action words (verbs), connector capabilities, and Plays, with shipping status.

Wired into `sidebars/bryn.ts` under a new **Reference** section.

**Testing**: Docusaurus build validates doc ids in the sidebar resolve and frontmatter parses; lychee link check covers links. Content mirrors the previously-reviewed source and passed the style-guide gate (sentence case, no internal references).

**Notes**: These pages were previously drafted in the `civicteam/bryn` repo; per ticket confirmation the canonical public copies live here in docs.civic.com. The internal projected-I/O "scrap paper" doc stays in the bryn repo.