### PR TITLE
docs(bryn): advertise only the tenant-specific MCP URL [BRYN-1424]

### DIFF
--- a/docs/bryn/api-overview.mdx
+++ b/docs/bryn/api-overview.mdx
@@ -12,7 +12,8 @@ Bryn knows. The same capabilities are exposed to AI clients through the
 ## Base URLs
 
 - **REST API:** `https://bryn.civic.com/api`
-- **MCP endpoint:** `https://bryn.civic.com/mcp`
+- **MCP endpoint:** `https://bryn.civic.com/mcp?tenant=<tenantId>` (see the
+  [MCP server](/bryn/mcp) page for where to find your tenant-specific URL)
 
 ## Authentication
 

--- a/docs/bryn/mcp.mdx
+++ b/docs/bryn/mcp.mdx
@@ -13,9 +13,22 @@ this. It speaks **streamable HTTP** and is secured with **Civic Auth** over OAut
 
 ## Endpoint
 
+The MCP URL is tenant-specific: it names the Bryn workspace the connection
+operates on via the `tenant` query parameter.
+
 ```
-https://bryn.civic.com/mcp
+https://bryn.civic.com/mcp?tenant=<tenantId>
 ```
+
+Copy your ready-made URL — with your tenant ID filled in — from the Bryn
+dashboard under
+[Integrations → MCP](https://bryn.civic.com/web/integrations/mcp).
+
+<Note>
+Clients that can send custom headers may pass `X-Bryn-Tenant: <tenantId>`
+instead of the query parameter. Most MCP clients can't set headers, so the
+query parameter is the primary form.
+</Note>
 
 ## Authentication
 
@@ -23,28 +36,21 @@ The server is secured with **Civic Auth** over OAuth. Clients that support OAuth
 open the Bryn login page in your browser the first time you connect: sign in there,
 and the client is authorized automatically. There's no token or API key to copy.
 
-Your tenant is resolved from your Civic Auth membership, the same way the
-[REST API](/bryn/api/bryn-control-plane-api) resolves it:
-
-- One membership → that tenant is selected automatically; nothing to configure.
-- More than one → pin the tenant in the connector URL with the `tenant` query
-  parameter: `https://bryn.civic.com/mcp?tenant=<tenantId>`. Most MCP clients can't
-  set custom headers, so the query parameter is the practical selector — but the
-  `X-Bryn-Tenant: <tenantId>` header works too where a client can set one.
-- Multi-membership with neither selector → `403 ambiguous_tenant`.
-- A tenant you don't belong to → `403 tenant_forbidden`.
-
-<Note>
-The `tenant` query parameter and the `X-Bryn-Tenant` header are selectors, not the
-source of truth: the tenant bound at the data layer is always taken from the matched
-membership. Naming different tenants in the two is rejected.
-</Note>
+Access is governed by your Civic Auth membership, the same way the
+[REST API](/bryn/api/bryn-control-plane-api) resolves it: the `tenant`
+parameter is a selector validated against your memberships, and the tenant
+bound at the data layer is always taken from the matched membership. Naming
+a tenant you don't belong to is rejected with `403 tenant_forbidden`.
 
 ## Connecting
 
 Clients that don't yet support remote MCP servers with OAuth can bridge through
 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), which handles the OAuth
 flow locally.
+
+In the snippets below, replace the URL with the one you copied from
+[Integrations → MCP](https://bryn.civic.com/web/integrations/mcp) (or swap in
+your tenant ID for `<tenantId>`).
 
 <Tabs>
   <Tab title="Claude Desktop">
@@ -55,7 +61,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "bryn": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://bryn.civic.com/mcp"]
+      "args": ["-y", "mcp-remote", "https://bryn.civic.com/mcp?tenant=<tenantId>"]
     }
   }
 }
@@ -71,7 +77,7 @@ Add to `~/.cursor/mcp.json` (or a project `.cursor/mcp.json`):
   "mcpServers": {
     "bryn": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://bryn.civic.com/mcp"]
+      "args": ["-y", "mcp-remote", "https://bryn.civic.com/mcp?tenant=<tenantId>"]
     }
   }
 }
@@ -87,7 +93,7 @@ Add to `.vscode/mcp.json`:
   "servers": {
     "bryn": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://bryn.civic.com/mcp"]
+      "args": ["-y", "mcp-remote", "https://bryn.civic.com/mcp?tenant=<tenantId>"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to the RFC 9207 issuer-mismatch fix: the bare `https://bryn.civic.com/mcp` URL 403s on initialize for multi-tenant and tenantless users (BRYN-1419), so the docs now advertise only the tenant-specific form `https://bryn.civic.com/mcp?tenant=<tenantId>`.

- **`docs/bryn/mcp.mdx`**: endpoint section shows only the tenant-specific URL and points users to the Bryn dashboard ([Integrations → MCP](https://bryn.civic.com/web/integrations/mcp)) to copy their ready-made URL; `X-Bryn-Tenant` header demoted to a secondary note for clients that can set custom headers; all three client snippets (Claude Desktop, Cursor, VS Code) updated; membership-resolution bullets collapsed into a short paragraph since a selector-less connection is no longer advertised.
- **`docs/bryn/api-overview.mdx`**: MCP base URL updated to the tenant-specific form, linking to the MCP page.

## Verification

- `pnpm build` succeeds; grepped the built HTML — no page in the build still contains the bare MCP URL, and all occurrences on `/bryn/mcp` are the `?tenant=` form.
- The dashboard deep link redirects to login and resolves 200, so no lychee ignore entry is needed.